### PR TITLE
Fix possible memory confusion in unsafe slice cast

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -117,13 +117,14 @@ func GetString(b []byte) string {
 // #nosec G103
 // GetBytes returns a byte pointer without allocation
 func GetBytes(s string) []byte {
+	b := make([]byte, 0, 0)
 	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
-	bh := reflect.SliceHeader{
-		Data: sh.Data,
-		Len:  sh.Len,
-		Cap:  sh.Len,
-	}
-	return *(*[]byte)(unsafe.Pointer(&bh))
+	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	bh.Data = sh.Data
+	bh.Cap = sh.Len
+	bh.Len = sh.Len
+	runtime.KeepAlive(s)
+	return b
 }
 
 // AssertEqual checks if values are equal

--- a/utils.go
+++ b/utils.go
@@ -117,7 +117,7 @@ func GetString(b []byte) string {
 // #nosec G103
 // GetBytes returns a byte pointer without allocation
 func GetBytes(s string) []byte {
-	b := make([]byte, 0, 0)
+	b := make([]byte, 0)
 	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
 	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 	bh.Data = sh.Data

--- a/utils.go
+++ b/utils.go
@@ -116,15 +116,13 @@ func GetString(b []byte) string {
 
 // #nosec G103
 // GetBytes returns a byte pointer without allocation
-func GetBytes(s string) []byte {
-	b := make([]byte, 0)
+func GetBytes(s string) (bs []byte) {
 	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
-	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	bh := (*reflect.SliceHeader)(unsafe.Pointer(&bs))
 	bh.Data = sh.Data
 	bh.Cap = sh.Len
 	bh.Len = sh.Len
-	runtime.KeepAlive(s)
-	return b
+	return
 }
 
 // AssertEqual checks if values are equal


### PR DESCRIPTION
I found an incorrect cast from `string` to `[]byte` in `utils.go`. The problem is that when `reflect.SliceHeader` is created as a composite literal (instead of deriving it from an actual slice by cast), then the Go garbage collector will not treat its `Data` field as a reference. If the GC runs just between creating the `SliceHeader` and casting it into the final, real `[]byte` slice, then the underlying data might have been collected already, effectively making the returned `[]byte` slice a dangling pointer.

This has a low probability to occur, but projects that import this library might still use it in a code path that gets executed a lot, thus increasing the probability to happen. Depending on the memory layout at the time of the GC run, this could potentially create an information leak vulnerability.

This PR changes the function to create the `reflect.SliceHeader` from an actual slice by first instantiating the return value.