### PR TITLE
🦾  add Trim, TrimLeft and TrimRight for bytes

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -174,6 +174,15 @@ func TrimRight(s string, cutset byte) string {
 	return s[:lenStr]
 }
 
+// TrimRightBytes is the equivalent of bytes.TrimRight
+func TrimRightBytes(b []byte, cutset byte) []byte {
+	lenStr := len(b)
+	for lenStr > 0 && b[lenStr-1] == cutset {
+		lenStr--
+	}
+	return b[:lenStr]
+}
+
 // TrimLeft is the equivalent of strings.TrimLeft
 func TrimLeft(s string, cutset byte) string {
 	lenStr, start := len(s), 0
@@ -181,6 +190,15 @@ func TrimLeft(s string, cutset byte) string {
 		start++
 	}
 	return s[start:]
+}
+
+// TrimLeftBytes is the equivalent of bytes.TrimLeft
+func TrimLeftBytes(b []byte, cutset byte) []byte {
+	lenStr, start := len(b), 0
+	for start < lenStr && b[start] == cutset {
+		start++
+	}
+	return b[start:]
 }
 
 // Trim is the equivalent of strings.Trim
@@ -198,6 +216,23 @@ func Trim(s string, cutset byte) string {
 	}
 
 	return s[i : j+1]
+}
+
+// TrimBytes is the equivalent of bytes.Trim
+func TrimBytes(b []byte, cutset byte) []byte {
+	i, j := 0, len(b)-1
+	for ; i < j; i++ {
+		if b[i] != cutset {
+			break
+		}
+	}
+	for ; i < j; j-- {
+		if b[j] != cutset {
+			break
+		}
+	}
+
+	return b[i : j+1]
 }
 
 // EqualFold the equivalent of bytes.EqualFold

--- a/utils.go
+++ b/utils.go
@@ -28,10 +28,6 @@ import (
 const toLowerTable = "\x00\x01\x02\x03\x04\x05\x06\a\b\t\n\v\f\r\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f !\"#$%&'()*+,-./0123456789:;<=>?@abcdefghijklmnopqrstuvwxyz[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u007f\x80\x81\x82\x83\x84\x85\x86\x87\x88\x89\x8a\x8b\x8c\x8d\x8e\x8f\x90\x91\x92\x93\x94\x95\x96\x97\x98\x99\x9a\x9b\x9c\x9d\x9e\x9f\xa0\xa1\xa2\xa3\xa4\xa5\xa6\xa7\xa8\xa9\xaa\xab\xac\xad\xae\xaf\xb0\xb1\xb2\xb3\xb4\xb5\xb6\xb7\xb8\xb9\xba\xbb\xbc\xbd\xbe\xbf\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf\xd0\xd1\xd2\xd3\xd4\xd5\xd6\xd7\xd8\xd9\xda\xdb\xdc\xdd\xde\xdf\xe0\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xeb\xec\xed\xee\xef\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xfa\xfb\xfc\xfd\xfe\xff"
 const toUpperTable = "\x00\x01\x02\x03\x04\x05\x06\a\b\t\n\v\f\r\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`ABCDEFGHIJKLMNOPQRSTUVWXYZ{|}~\u007f\x80\x81\x82\x83\x84\x85\x86\x87\x88\x89\x8a\x8b\x8c\x8d\x8e\x8f\x90\x91\x92\x93\x94\x95\x96\x97\x98\x99\x9a\x9b\x9c\x9d\x9e\x9f\xa0\xa1\xa2\xa3\xa4\xa5\xa6\xa7\xa8\xa9\xaa\xab\xac\xad\xae\xaf\xb0\xb1\xb2\xb3\xb4\xb5\xb6\xb7\xb8\xb9\xba\xbb\xbc\xbd\xbe\xbf\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf\xd0\xd1\xd2\xd3\xd4\xd5\xd6\xd7\xd8\xd9\xda\xdb\xdc\xdd\xde\xdf\xe0\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xeb\xec\xed\xee\xef\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xfa\xfb\xfc\xfd\xfe\xff"
 
-func init() {
-	initStatusMessage()
-}
-
 // Returns total memory in bytes
 func MemoryTotal() uint64 {
 	return memory.TotalMemory()
@@ -348,83 +344,84 @@ func GetArgument(arg string) bool {
 	return false
 }
 
-// StatusMessage ...
+// limit for the access
+const (
+	statusMessageMin = 100
+	statusMessageMax = 511
+)
+
+// StatusMessage returns the correct message for the provided HTTP statuscode
 func StatusMessage(status int) string {
-	if status < 0 || status >= statusMessageLimit {
+	if status < statusMessageMin || status > statusMessageMax {
 		return ""
 	}
 	return statusMessage[status]
 }
 
-// limit for the access
-const statusMessageLimit = 600
-
 // HTTP status codes were copied from net/http.
-var statusMessage = make([]string, statusMessageLimit)
-
-func initStatusMessage() {
-	statusMessage[100] = "Continue"
-	statusMessage[101] = "Switching Protocols"
-	statusMessage[102] = "Processing"
-	statusMessage[103] = "Early Hints"
-	statusMessage[200] = "OK"
-	statusMessage[201] = "Created"
-	statusMessage[202] = "Accepted"
-	statusMessage[203] = "Non-Authoritative Information"
-	statusMessage[204] = "No Content"
-	statusMessage[205] = "Reset Content"
-	statusMessage[206] = "Partial Content"
-	statusMessage[207] = "Multi-Status"
-	statusMessage[208] = "Already Reported"
-	statusMessage[226] = "IM Used"
-	statusMessage[300] = "Multiple Choices"
-	statusMessage[301] = "Moved Permanently"
-	statusMessage[302] = "Found"
-	statusMessage[303] = "See Other"
-	statusMessage[304] = "Not Modified"
-	statusMessage[305] = "Use Proxy"
-	statusMessage[306] = "Switch Proxy"
-	statusMessage[307] = "Temporary Redirect"
-	statusMessage[308] = "Permanent Redirect"
-	statusMessage[400] = "Bad Request"
-	statusMessage[401] = "Unauthorized"
-	statusMessage[402] = "Payment Required"
-	statusMessage[403] = "Forbidden"
-	statusMessage[404] = "Not Found"
-	statusMessage[405] = "Method Not Allowed"
-	statusMessage[406] = "Not Acceptable"
-	statusMessage[407] = "Proxy Authentication Required"
-	statusMessage[408] = "Request Timeout"
-	statusMessage[409] = "Conflict"
-	statusMessage[410] = "Gone"
-	statusMessage[411] = "Length Required"
-	statusMessage[412] = "Precondition Failed"
-	statusMessage[413] = "Request Entity Too Large"
-	statusMessage[414] = "Request URI Too Long"
-	statusMessage[415] = "Unsupported Media Type"
-	statusMessage[416] = "Requested Range Not Satisfiable"
-	statusMessage[417] = "Expectation Failed"
-	statusMessage[418] = "I'm a teapot"
-	statusMessage[421] = "Misdirected Request"
-	statusMessage[422] = "Unprocessable Entity"
-	statusMessage[423] = "Locked"
-	statusMessage[424] = "Failed Dependency"
-	statusMessage[426] = "Upgrade Required"
-	statusMessage[428] = "Precondition Required"
-	statusMessage[429] = "Too Many Requests"
-	statusMessage[431] = "Request Header Fields Too Large"
-	statusMessage[451] = "Unavailable For Legal Reasons"
-	statusMessage[500] = "Internal Server Error"
-	statusMessage[501] = "Not Implemented"
-	statusMessage[502] = "Bad Gateway"
-	statusMessage[503] = "Service Unavailable"
-	statusMessage[504] = "Gateway Timeout"
-	statusMessage[505] = "HTTP Version Not Supported"
-	statusMessage[506] = "Variant Also Negotiates"
-	statusMessage[507] = "Insufficient Storage"
-	statusMessage[508] = "Loop Detected"
-	statusMessage[510] = "Not Extended"
-	statusMessage[511] = "Network Authentication Required"
+var statusMessage = []string{
+	100: "Continue",
+	101: "Switching Protocols",
+	102: "Processing",
+	103: "Early Hints",
+	200: "OK",
+	201: "Created",
+	202: "Accepted",
+	203: "Non-Authoritative Information",
+	204: "No Content",
+	205: "Reset Content",
+	206: "Partial Content",
+	207: "Multi-Status",
+	208: "Already Reported",
+	226: "IM Used",
+	300: "Multiple Choices",
+	301: "Moved Permanently",
+	302: "Found",
+	303: "See Other",
+	304: "Not Modified",
+	305: "Use Proxy",
+	306: "Switch Proxy",
+	307: "Temporary Redirect",
+	308: "Permanent Redirect",
+	400: "Bad Request",
+	401: "Unauthorized",
+	402: "Payment Required",
+	403: "Forbidden",
+	404: "Not Found",
+	405: "Method Not Allowed",
+	406: "Not Acceptable",
+	407: "Proxy Authentication Required",
+	408: "Request Timeout",
+	409: "Conflict",
+	410: "Gone",
+	411: "Length Required",
+	412: "Precondition Failed",
+	413: "Request Entity Too Large",
+	414: "Request URI Too Long",
+	415: "Unsupported Media Type",
+	416: "Requested Range Not Satisfiable",
+	417: "Expectation Failed",
+	418: "I'm a teapot",
+	421: "Misdirected Request",
+	422: "Unprocessable Entity",
+	423: "Locked",
+	424: "Failed Dependency",
+	426: "Upgrade Required",
+	428: "Precondition Required",
+	429: "Too Many Requests",
+	431: "Request Header Fields Too Large",
+	451: "Unavailable For Legal Reasons",
+	500: "Internal Server Error",
+	501: "Not Implemented",
+	502: "Bad Gateway",
+	503: "Service Unavailable",
+	504: "Gateway Timeout",
+	505: "HTTP Version Not Supported",
+	506: "Variant Also Negotiates",
+	507: "Insufficient Storage",
+	508: "Loop Detected",
+	510: "Not Extended",
+	511: "Network Authentication Required",
 }
 
 // MIME types were copied from https://github.com/nginx/nginx/blob/master/conf/mime.types

--- a/utils_bench_test.go
+++ b/utils_bench_test.go
@@ -97,13 +97,13 @@ func Benchmark_GetMIME(b *testing.B) {
 	})
 }
 
-// go test -v -run=^$ -bench=Benchmark_StatusMessage -benchmem -count=2
+// go test -v -run=^$ -bench=Benchmark_StatusMessage -benchmem -count=4
 func Benchmark_StatusMessage(b *testing.B) {
 	var res string
 	for n := 0; n < b.N; n++ {
-		res = StatusMessage(http.StatusNotFound)
+		res = StatusMessage(http.StatusNotExtended)
 	}
-	AssertEqual(b, "Not Found", res)
+	AssertEqual(b, "Not Extended", res)
 }
 
 func Benchmark_ToLower(b *testing.B) {

--- a/utils_bench_test.go
+++ b/utils_bench_test.go
@@ -217,6 +217,24 @@ func Benchmark_Trim(b *testing.B) {
 		AssertEqual(b, "foobar", res)
 	})
 }
+
+func Benchmark_TrimBytes(b *testing.B) {
+	var res []byte
+
+	b.Run("fiber", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			res = TrimBytes([]byte("  foobar   "), ' ')
+		}
+		AssertEqual(b, []byte("foobar"), res)
+	})
+	b.Run("default", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			res = bytes.Trim([]byte("  foobar   "), " ")
+		}
+		AssertEqual(b, []byte("foobar"), res)
+	})
+}
+
 func Benchmark_TrimLeft(b *testing.B) {
 	var res string
 
@@ -233,6 +251,24 @@ func Benchmark_TrimLeft(b *testing.B) {
 		AssertEqual(b, "foobar", res)
 	})
 }
+
+func Benchmark_TrimLeftBytes(b *testing.B) {
+	var res []byte
+
+	b.Run("fiber", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			res = TrimLeftBytes([]byte("  foobar"), ' ')
+		}
+		AssertEqual(b, []byte("foobar"), res)
+	})
+	b.Run("default", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			res = bytes.TrimLeft([]byte("  foobar"), " ")
+		}
+		AssertEqual(b, []byte("foobar"), res)
+	})
+}
+
 func Benchmark_TrimRight(b *testing.B) {
 	var res string
 
@@ -247,5 +283,22 @@ func Benchmark_TrimRight(b *testing.B) {
 			res = strings.TrimRight("foobar  ", " ")
 		}
 		AssertEqual(b, "foobar", res)
+	})
+}
+
+func Benchmark_TrimRightBytes(b *testing.B) {
+	var res []byte
+
+	b.Run("fiber", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			res = TrimRightBytes([]byte("foobar  "), ' ')
+		}
+		AssertEqual(b, []byte("foobar"), res)
+	})
+	b.Run("default", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			res = bytes.TrimRight([]byte("foobar  "), " ")
+		}
+		AssertEqual(b, []byte("foobar"), res)
 	})
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -104,6 +104,35 @@ func Test_Utils_Trim(t *testing.T) {
 	AssertEqual(t, "test", res)
 }
 
+func Test_Utils_TrimRightBytes(t *testing.T) {
+	t.Parallel()
+	res := TrimRightBytes([]byte("/test//////"), '/')
+	AssertEqual(t, []byte("/test"), res)
+
+	res = TrimRightBytes([]byte("/test"), '/')
+	AssertEqual(t, []byte("/test"), res)
+}
+
+func Test_Utils_TrimLeftBytes(t *testing.T) {
+	t.Parallel()
+	res := TrimLeftBytes([]byte("////test/"), '/')
+	AssertEqual(t, []byte("test/"), res)
+
+	res = TrimLeftBytes([]byte("test/"), '/')
+	AssertEqual(t, []byte("test/"), res)
+}
+func Test_Utils_TrimBytes(t *testing.T) {
+	t.Parallel()
+	res := TrimBytes([]byte("   test  "), ' ')
+	AssertEqual(t, []byte("test"), res)
+
+	res = TrimBytes([]byte("test"), ' ')
+	AssertEqual(t, []byte("test"), res)
+
+	res = TrimBytes([]byte(".test"), '.')
+	AssertEqual(t, []byte("test"), res)
+}
+
 // func Test_Utils_getArgument(t *testing.T) {
 // 	// TODO
 // }


### PR DESCRIPTION
```go
Benchmark_TrimBytes/fiber-12             39803058        28.7 ns/op      16 B/op       1 allocs/op
Benchmark_TrimBytes/fiber-12             39002168        28.7 ns/op      16 B/op       1 allocs/op
Benchmark_TrimBytes/fiber-12             43191133        28.7 ns/op      16 B/op       1 allocs/op
Benchmark_TrimBytes/default-12           10732539         120 ns/op      48 B/op       2 allocs/op
Benchmark_TrimBytes/default-12           10415397         108 ns/op      48 B/op       2 allocs/op
Benchmark_TrimBytes/default-12           10746268         108 ns/op      48 B/op       2 allocs/op

Benchmark_TrimLeftBytes/fiber-12         51428390        21.0 ns/op       8 B/op       1 allocs/op
Benchmark_TrimLeftBytes/fiber-12         49599015        23.0 ns/op       8 B/op       1 allocs/op
Benchmark_TrimLeftBytes/fiber-12         38680032        27.2 ns/op       8 B/op       1 allocs/op
Benchmark_TrimLeftBytes/default-12       13552348        82.2 ns/op      40 B/op       2 allocs/op
Benchmark_TrimLeftBytes/default-12       15555775        86.2 ns/op      40 B/op       2 allocs/op
Benchmark_TrimLeftBytes/default-12       13822734        84.5 ns/op      40 B/op       2 allocs/op

Benchmark_TrimRightBytes/fiber-12        48953707        21.4 ns/op       8 B/op       1 allocs/op
Benchmark_TrimRightBytes/fiber-12        54373020        22.3 ns/op       8 B/op       1 allocs/op
Benchmark_TrimRightBytes/fiber-12        51378205        21.6 ns/op       8 B/op       1 allocs/op
Benchmark_TrimRightBytes/default-12      13947445        81.6 ns/op      40 B/op       2 allocs/op
Benchmark_TrimRightBytes/default-12      14524773        78.6 ns/op      40 B/op       2 allocs/op
Benchmark_TrimRightBytes/default-12      15764966        86.2 ns/op      40 B/op       2 allocs/op
```