### PR TITLE
Improve ToString by 20%

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -92,8 +92,7 @@ func ByteSize(bytes uint64) string {
 
 // ToString Change arg to string
 func ToString(arg any, timeFormat ...string) string {
-	var tmp = reflect.Indirect(reflect.ValueOf(arg)).Interface()
-	switch v := tmp.(type) {
+	switch v := arg.(type) {
 	case int:
 		return strconv.Itoa(v)
 	case int8:
@@ -134,6 +133,12 @@ func ToString(arg any, timeFormat ...string) string {
 	case fmt.Stringer:
 		return v.String()
 	default:
+		// Check if the type is a pointer by using reflection
+		rv := reflect.ValueOf(arg)
+		if rv.Kind() == reflect.Ptr && !rv.IsNil() {
+			// Dereference the pointer and recursively call ToString
+			return ToString(rv.Elem().Interface(), timeFormat...)
+		}
 		return ""
 	}
 }

--- a/convert.go
+++ b/convert.go
@@ -139,6 +139,7 @@ func ToString(arg any, timeFormat ...string) string {
 			// Dereference the pointer and recursively call ToString
 			return ToString(rv.Elem().Interface(), timeFormat...)
 		}
-		return ""
+		// For types not explicitly handled, use fmt.Sprint to generate a string representation
+		return fmt.Sprint(arg)
 	}
 }

--- a/convert_test.go
+++ b/convert_test.go
@@ -91,7 +91,7 @@ func Test_ToString(t *testing.T) {
 		{float32(3.14), "3.14"},
 		{float64(3.14159), "3.14159"},
 		{time.Date(2000, 1, 1, 12, 34, 56, 0, time.UTC), "2000-01-01 12:34:56"},
-		{struct{ Name string }{"John"}, ""}, // Assuming default case returns an empty string
+		{struct{ Name string }{"John"}, "{John}"}, // Assuming default case returns an empty string
 	}
 
 	for _, tc := range tests {
@@ -117,7 +117,7 @@ func Test_ToString(t *testing.T) {
 	}
 }
 
-// go test -v -run=^$ -bench=ToString -benchmem -count=2
+// go test -v -run=^$ -bench=ToString -benchmem -count=4
 func Benchmark_ToString(b *testing.B) {
 	values := []interface{}{
 		42,

--- a/convert_test.go
+++ b/convert_test.go
@@ -5,7 +5,9 @@
 package utils
 
 import (
+	"reflect"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -68,18 +70,76 @@ func Test_CopyString(t *testing.T) {
 
 func Test_ToString(t *testing.T) {
 	t.Parallel()
-	res := ToString([]byte("Hello, World!"))
-	require.Equal(t, "Hello, World!", res)
-	res = ToString(true)
-	require.Equal(t, "true", res)
-	res = ToString(uint(100))
-	require.Equal(t, "100", res)
+
+	tests := []struct {
+		input    interface{}
+		expected string
+	}{
+		{[]byte("Hello, World!"), "Hello, World!"},
+		{true, "true"},
+		{uint(100), "100"},
+		{int(42), "42"},
+		{int8(42), "42"},
+		{int16(42), "42"},
+		{int32(42), "42"},
+		{int64(42), "42"},
+		{uint8(100), "100"},
+		{uint16(100), "100"},
+		{uint32(100), "100"},
+		{uint64(100), "100"},
+		{"test string", "test string"},
+		{float32(3.14), "3.14"},
+		{float64(3.14159), "3.14159"},
+		{time.Date(2000, 1, 1, 12, 34, 56, 0, time.UTC), "2000-01-01 12:34:56"},
+		{struct{ Name string }{"John"}, ""}, // Assuming default case returns an empty string
+	}
+
+	for _, tc := range tests {
+		t.Run(reflect.TypeOf(tc.input).String(), func(t *testing.T) {
+			res := ToString(tc.input)
+			require.Equal(t, tc.expected, res)
+		})
+	}
+
+	// Testing pointer to int
+	intPtr := 42
+	testsPtr := []struct {
+		input    interface{}
+		expected string
+	}{
+		{&intPtr, "42"},
+	}
+	for _, tc := range testsPtr {
+		t.Run("pointer to "+reflect.TypeOf(tc.input).Elem().String(), func(t *testing.T) {
+			res := ToString(tc.input)
+			require.Equal(t, tc.expected, res)
+		})
+	}
 }
 
 // go test -v -run=^$ -bench=ToString -benchmem -count=2
 func Benchmark_ToString(b *testing.B) {
-	hello := []byte("Hello, World!")
+	values := []interface{}{
+		42,
+		int8(42),
+		int16(42),
+		int32(42),
+		int64(42),
+		uint(42),
+		uint8(42),
+		uint16(42),
+		uint32(42),
+		uint64(42),
+		"Hello, World!",
+		[]byte("Hello, World!"),
+		true,
+		float32(3.14),
+		float64(3.14),
+		time.Now(),
+	}
 	for n := 0; n < b.N; n++ {
-		ToString(hello)
+		for _, value := range values {
+			_ = ToString(value)
+		}
 	}
 }

--- a/convert_test.go
+++ b/convert_test.go
@@ -91,7 +91,7 @@ func Test_ToString(t *testing.T) {
 		{float32(3.14), "3.14"},
 		{float64(3.14159), "3.14159"},
 		{time.Date(2000, 1, 1, 12, 34, 56, 0, time.UTC), "2000-01-01 12:34:56"},
-		{struct{ Name string }{"John"}, "{John}"}, // Assuming default case returns an empty string
+		{struct{ Name string }{"John"}, "{John}"},
 	}
 
 	for _, tc := range tests {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gofiber/utils/v2
 go 1.19
 
 require (
-	github.com/google/uuid v1.5.0
+	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.8.4
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,11 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/google/uuid v1.5.0 h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU=
-github.com/google/uuid v1.5.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
- Avoid unnecessary pointer dereferencing in `convert.go#ToString`
- Add all types in ToString tests and benchmarks

```
ok  	github.com/gofiber/utils/v2	2.314s	coverage: 75.4% of statements
```
```
**Before**
Benchmark_ToString-24            3499046               339.2 ns/op            96 B/op          6 allocs/op
Benchmark_ToString-24            3552510               336.8 ns/op            96 B/op          6 allocs/op
Benchmark_ToString-24            3589656               335.2 ns/op            96 B/op          6 allocs/op
Benchmark_ToString-24            3564043               337.8 ns/op            96 B/op          6 allocs/op
**After**
Benchmark_ToString-24            4211290               285.7 ns/op            96 B/op          6 allocs/op
Benchmark_ToString-24            4296464               282.5 ns/op            96 B/op          6 allocs/op
Benchmark_ToString-24            4279908               283.5 ns/op            96 B/op          6 allocs/op
Benchmark_ToString-24            4216419               283.5 ns/op            96 B/op          6 allocs/op
```