### PR TITLE
Improve UnsafeBytes with Go 1.20+

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -25,13 +25,7 @@ func UnsafeString(b []byte) string {
 // UnsafeBytes returns a byte pointer without allocation.
 // String length shouldn't be more than 2147418112.
 func UnsafeBytes(s string) []byte {
-	if s == "" {
-		return nil
-	}
-
-	return (*[MaxStringLen]byte)(unsafe.Pointer(
-		(*reflect.StringHeader)(unsafe.Pointer(&s)).Data),
-	)[:len(s):len(s)]
+	return unsafe.Slice(unsafe.StringData(s), len(s))
 }
 
 // CopyString copies a string to make it immutable

--- a/convert.go
+++ b/convert.go
@@ -23,7 +23,6 @@ func UnsafeString(b []byte) string {
 
 // #nosec G103
 // UnsafeBytes returns a byte pointer without allocation.
-// String length shouldn't be more than 2147418112.
 func UnsafeBytes(s string) []byte {
 	return unsafe.Slice(unsafe.StringData(s), len(s))
 }

--- a/convert_test.go
+++ b/convert_test.go
@@ -91,7 +91,7 @@ func Test_ToString(t *testing.T) {
 		{float32(3.14), "3.14"},
 		{float64(3.14159), "3.14159"},
 		{time.Date(2000, 1, 1, 12, 34, 56, 0, time.UTC), "2000-01-01 12:34:56"},
-		{struct{ Name string }{"John"}, "{John}"}, // Assuming default case returns an empty string
+		{struct{ Name string }{"John"}, "{John}"},
 	}
 
 	for _, tc := range tests {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gofiber/utils/v2
 
-go 1.19
+go 1.21
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
```go
func UnsafeBytes(s string) []byte {
    if s == "" {
        return nil
    }
    return (*[MaxStringLen]byte)(unsafe.Pointer(
        (*reflect.StringHeader)(unsafe.Pointer(&s)).Data),
    )[:len(s):len(s)]
}
//Benchmark_UnsafeBytes/unsafe-24                 1000000000               0.8708 ns/op          0 B/op          0 allocs/op
//Benchmark_UnsafeBytes/unsafe-24                 1000000000               1.043 ns/op           0 B/op          0 allocs/op
//Benchmark_UnsafeBytes/unsafe-24                 1000000000               0.8187 ns/op          0 B/op          0 allocs/op
//Benchmark_UnsafeBytes/unsafe-24                 1000000000               0.7915 ns/op          0 B/op          0 allocs/op

func UnsafeBytes(s string) []byte {
    return unsafe.Slice(unsafe.StringData(s), len(s))
}
//Benchmark_UnsafeBytes/unsafe-24                 1000000000               0.3992 ns/op          0 B/op          0 allocs/op
//Benchmark_UnsafeBytes/unsafe-24                 1000000000               0.3953 ns/op          0 B/op          0 allocs/op
//Benchmark_UnsafeBytes/unsafe-24                 1000000000               0.3975 ns/op          0 B/op          0 allocs/op
//Benchmark_UnsafeBytes/unsafe-24                 1000000000               0.3997 ns/op          0 B/op          0 allocs/op
```