### PR TITLE
Fix mismatch minimum go version to match gofiber/fiber

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.21.x
+        go-version: 1.20.x
 
     - name: Fetch Repository
       uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
   Build:
     strategy:
       matrix:
-        go-version: [1.20.x, 1.21.x]
+        go-version: [1.20.x, 1.21.x, 1.22.x]
         platform: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/convert.go
+++ b/convert.go
@@ -13,25 +13,27 @@ import (
 	"unsafe"
 )
 
-// #nosec G103
 // UnsafeString returns a string pointer without allocation
 func UnsafeString(b []byte) string {
 	// the new way is slower `return unsafe.String(unsafe.SliceData(b), len(b))`
 	// unsafe.Pointer variant: 0.3538 ns/op vs unsafe.String variant: 0.5410 ns/op
+	// #nosec G103
 	return *(*string)(unsafe.Pointer(&b))
 }
 
-// #nosec G103
 // UnsafeBytes returns a byte pointer without allocation.
 func UnsafeBytes(s string) []byte {
+	// #nosec G103
 	return unsafe.Slice(unsafe.StringData(s), len(s))
 }
 
 // CopyString copies a string to make it immutable
 func CopyString(s string) string {
+	// #nosec G103
 	return string(UnsafeBytes(s))
 }
 
+// #nosec G103
 // CopyBytes copies a slice to make it immutable
 func CopyBytes(b []byte) []byte {
 	tmp := make([]byte, len(b))

--- a/file.go
+++ b/file.go
@@ -21,7 +21,6 @@ func Walk(fs http.FileSystem, root string, walkFn filepath.WalkFunc) error {
 	return walk(fs, root, info, walkFn)
 }
 
-// #nosec G304
 // ReadFile returns the raw content of a file
 func ReadFile(path string, fs http.FileSystem) ([]byte, error) {
 	if fs != nil {
@@ -32,7 +31,7 @@ func ReadFile(path string, fs http.FileSystem) ([]byte, error) {
 		defer file.Close()
 		return io.ReadAll(file)
 	}
-	return os.ReadFile(path)
+	return os.ReadFile(path) // #nosec G304
 }
 
 // readDirNames reads the directory named by dirname and returns

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gofiber/utils/v2
 
-go 1.21
+go 1.20
 
 require (
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
- The min go version for gofiber/utils does not match the min version of gofiber/fiber. See here https://github.com/gofiber/fiber/blob/main/go.mod#L3
- Added go1.22 to matrix