### PR TITLE
Fix IPv4 boundary checking

### DIFF
--- a/ips.go
+++ b/ips.go
@@ -21,7 +21,7 @@ func IsIPv4(s string) bool {
 
 		for ci = 0; ci < len(s) && '0' <= s[ci] && s[ci] <= '9'; ci++ {
 			n = n*10 + int(s[ci]-'0')
-			if n >= 0xFF {
+			if n > 0xFF {
 				return false
 			}
 		}

--- a/ips_test.go
+++ b/ips_test.go
@@ -14,6 +14,7 @@ import (
 func Test_IsIPv4(t *testing.T) {
 	t.Parallel()
 
+	require.Equal(t, true, IsIPv4("255.255.255.255"))
 	require.Equal(t, true, IsIPv4("174.23.33.100"))
 	require.Equal(t, true, IsIPv4("127.0.0.1"))
 	require.Equal(t, true, IsIPv4("0.0.0.0"))
@@ -30,6 +31,7 @@ func Test_IsIPv4(t *testing.T) {
 	require.Equal(t, false, IsIPv4("189.12.34.260"))
 	require.Equal(t, false, IsIPv4("189.12.260.260"))
 	require.Equal(t, false, IsIPv4("189.260.260.260"))
+	require.Equal(t, false, IsIPv4("255.255.255.256"))
 	require.Equal(t, false, IsIPv4("999.999.999.999"))
 	require.Equal(t, false, IsIPv4("9999.9999.9999.9999"))
 


### PR DESCRIPTION
"255.255.255.255" is correct for IPv4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the accuracy of IPv4 address validation.
- **Tests**
	- Added a test case to ensure invalid IPv4 addresses are correctly identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->