### PR TITLE
RFC8478 - Add the application/zstd Media Type

### DIFF
--- a/http.go
+++ b/http.go
@@ -232,6 +232,7 @@ var mimeExtensions = map[string]string{
 	"xhtml":   "application/xhtml+xml",
 	"xspf":    "application/xspf+xml",
 	"zip":     "application/zip",
+	"zst":     "application/zstd",
 	"bin":     "application/octet-stream",
 	"exe":     "application/octet-stream",
 	"dll":     "application/octet-stream",

--- a/http_test.go
+++ b/http_test.go
@@ -26,6 +26,12 @@ func Test_GetMIME(t *testing.T) {
 	res = GetMIME("unknown")
 	require.Equal(t, MIMEOctetStream, res)
 
+	res := GetMIME(".zst")
+	require.Equal(t, "application/zstd", res)
+
+	res := GetMIME("zst")
+	require.Equal(t, "application/zstd", res)
+
 	// empty case
 	res = GetMIME("")
 	require.Equal(t, "", res)

--- a/http_test.go
+++ b/http_test.go
@@ -26,10 +26,10 @@ func Test_GetMIME(t *testing.T) {
 	res = GetMIME("unknown")
 	require.Equal(t, MIMEOctetStream, res)
 
-	res := GetMIME(".zst")
+	res = GetMIME(".zst")
 	require.Equal(t, "application/zstd", res)
 
-	res := GetMIME("zst")
+	res = GetMIME("zst")
 	require.Equal(t, "application/zstd", res)
 
 	// empty case


### PR DESCRIPTION
Add `application/zstd` mime type which uses ".zst" as extension.

Source: https://datatracker.ietf.org/doc/rfc8478/
FastHTTP: https://github.com/valyala/fasthttp/pull/1701
Related: https://github.com/facebook/zstd/issues/767

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added support for `.zst` file MIME type.
- **Tests**
	- Improved testing for MIME type detection, including edge cases with file extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->