### PR TITLE
Bump golangci-lint to v1.59.1

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -40,4 +40,4 @@ jobs:
         uses: golangci/golangci-lint-action@v5
         with:
           # NOTE: Keep this in sync with the version from .golangci.yml
-          version: v1.57.1
+          version: v1.59.1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-# v1.2.0. Created based on golangci-lint v1.57.1
+# v1.2.0. Created based on golangci-lint v1.59.1
 
 run:
   timeout: 5m
@@ -238,11 +238,9 @@ linters-settings:
     time-layout: false # TODO: Set to true
     crypto-hash: true
     default-rpc-path: true
-    os-dev-null: true
     sql-isolation-level: true
     tls-signature-scheme: true
     constant-kind: true
-    syslog-priority: true
 
   wrapcheck:
     ignorePackageGlobs:
@@ -258,7 +256,7 @@ issues:
     - internal # TODO: Do not ignore interal packages
   exclude-rules:
     - linters:
-        - goerr113
+        - err113
       text: 'do not define dynamic errors, use wrapped static errors instead*'
     - path: log/.*\.go
       linters:
@@ -288,7 +286,6 @@ linters:
     - errchkjson
     - errname
     - errorlint
-    - execinquery
     - exhaustive
     # - exhaustivestruct
     # - exhaustruct
@@ -308,7 +305,7 @@ linters:
     # - gocyclo
     # - godot
     # - godox
-    - goerr113
+    - err113
     - gofmt
     - gofumpt
     # - goheader

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ format:
 ## lint: 🚨 Run lint checks
 .PHONY: lint
 lint:
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.57.1 run ./...
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1 run ./...
 
 ## test: 🚦 Execute all tests
 .PHONY: test


### PR DESCRIPTION
- Remove deprecated linters
- Updated golangci-lint from v1.57.1 to v1.59.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated `golangci-lint` version to `v1.59.1` in configuration files and Makefile for improved linting capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->