### PR TITLE
chore: Add support for go1.23 and golangci-lint v1.61.0

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           # NOTE: Keep this in sync with the version from go.mod
-          go-version: "1.21.x"
+          go-version: "1.22.x"
 
       - name: Run Benchmark
         run: set -o pipefail; go test ./... -benchmem -run=^$ -bench . | tee output.txt

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -33,11 +33,11 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           # NOTE: Keep this in sync with the version from go.mod
-          go-version: "1.21.x"
+          go-version: "1.22.x"
           cache: false
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
           # NOTE: Keep this in sync with the version from .golangci.yml
-          version: v1.59.1
+          version: v1.60.1

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -40,4 +40,4 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           # NOTE: Keep this in sync with the version from .golangci.yml
-          version: v1.60.1
+          version: v1.61.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,8 @@ jobs:
   Build:
     strategy:
       matrix:
-        go-version: [1.21.x, 1.22.x]
-        platform: [ubuntu-latest, windows-latest, macos-latest, macos-14]
+        go-version: [1.22.x, 1.23.x]
+        platform: [ubuntu-latest, windows-latest, macos-latest, macos-13]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Fetch Repository
@@ -40,7 +40,7 @@ jobs:
         run: gotestsum -f testname -- ./... -race -count=1 -coverprofile=coverage.txt -covermode=atomic -shuffle=on
 
       - name: Upload coverage reports to Codecov
-        if: ${{ matrix.platform == 'ubuntu-latest' && matrix.go-version == '1.22.x' }}
+        if: ${{ matrix.platform == 'ubuntu-latest' && matrix.go-version == '1.23.x' }}
         uses: codecov/codecov-action@v4.5.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -95,6 +95,7 @@ linters-settings:
   gosec:
     excludes:
       - G104 # TODO: Enable this again. Mostly provided by errcheck
+      - G115
     config:
       global:
         # show-ignored: true # TODO: Enable this
@@ -289,7 +290,6 @@ linters:
     - exhaustive
     # - exhaustivestruct
     # - exhaustruct
-    - exportloopref
     - forbidigo
     - forcetypeassert
     # - funlen

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ format:
 ## lint: 🚨 Run lint checks
 .PHONY: lint
 lint:
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.1 run ./...
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0 run ./...
 
 ## test: 🚦 Execute all tests
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ format:
 ## lint: 🚨 Run lint checks
 .PHONY: lint
 lint:
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1 run ./...
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.1 run ./...
 
 ## test: 🚦 Execute all tests
 .PHONY: test

--- a/README.md
+++ b/README.md
@@ -137,4 +137,4 @@ Benchmark_CalculateTimestamp/default-12        15789036        71.12 ns/op      
 
 ```
 
-See all the benchmarks under https://gofiber.github.io/utils/
+See all the benchmarks under <https://gofiber.github.io/utils/>

--- a/convert_test.go
+++ b/convert_test.go
@@ -191,7 +191,7 @@ func TestCopyBytes(t *testing.T) {
 	t.Run("nil slice", func(t *testing.T) {
 		copied := CopyBytes(nil)
 		require.NotNil(t, copied)
-		require.Empty(t, len(copied))
+		require.Empty(t, copied)
 		require.Equal(t, 0, cap(copied))
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gofiber/utils/v2
 
-go 1.21
+go 1.22
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
- Bump minimum go version to 1.22
- Bump golangci-lint to v1.61.0
  - Fix all issues exposed by golangci-lint
- Add go1.23 to CI
- macos-latest now points to arm-based `MacOS14`.
- re-added `macos-13` which is x86_64 based.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Upgraded to Go version 1.22.x and 1.23.x across testing workflows for improved performance and features.
	- Updated GolangCI-Lint tool to version 1.60.1, enhancing linting capabilities.

- **Bug Fixes**
	- Improved clarity in test assertions to ensure more intuitive verification of results.

- **Documentation**
	- Enhanced URL formatting in the README for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->