### PR TITLE
🔥 feat: Add support for stopping timestamp updater

### DIFF
--- a/time.go
+++ b/time.go
@@ -44,6 +44,7 @@ func StartTimeStampUpdater() {
 }
 
 // StopTimeStampUpdater stops the timestamp updater
+// WARNING: Make sure to call this function before the program exits, otherwise it will leak goroutines
 func StopTimeStampUpdater() {
 	if stopChan != nil {
 		close(stopChan)

--- a/time_test.go
+++ b/time_test.go
@@ -14,8 +14,6 @@ func checkTimeStamp(tb testing.TB, expectedCurrent, actualCurrent uint32) {
 }
 
 func Test_TimeStampUpdater(t *testing.T) {
-	t.Parallel()
-
 	StartTimeStampUpdater()
 
 	now := uint32(time.Now().Unix())
@@ -31,8 +29,6 @@ func Test_TimeStampUpdater(t *testing.T) {
 }
 
 func Test_StopTimeStampUpdater(t *testing.T) {
-	t.Parallel()
-
 	// Start the timestamp updater
 	StartTimeStampUpdater()
 
@@ -50,7 +46,7 @@ func Test_StopTimeStampUpdater(t *testing.T) {
 	stoppedTime := Timestamp()
 
 	// Wait again to see if it updates
-	time.Sleep(2 * time.Second)
+	time.Sleep(3 * time.Second)
 
 	// It should not have changed since we've stopped the updater
 	require.Equal(t, stoppedTime, Timestamp(), "timestamp should not change after stopping updater")

--- a/time_test.go
+++ b/time_test.go
@@ -30,6 +30,32 @@ func Test_TimeStampUpdater(t *testing.T) {
 	checkTimeStamp(t, now+2, Timestamp())
 }
 
+func Test_StopTimeStampUpdater(t *testing.T) {
+	t.Parallel()
+
+	// Start the timestamp updater
+	StartTimeStampUpdater()
+
+	now := uint32(time.Now().Unix())
+	checkTimeStamp(t, now, Timestamp())
+
+	// Wait for an increment
+	time.Sleep(1 * time.Second)
+	checkTimeStamp(t, now+1, Timestamp())
+
+	// Stop the updater
+	StopTimeStampUpdater()
+
+	// Capture the timestamp after stopping
+	stoppedTime := Timestamp()
+
+	// Wait again to see if it updates
+	time.Sleep(2 * time.Second)
+
+	// It should not have changed since we've stopped the updater
+	require.Equal(t, stoppedTime, Timestamp(), "timestamp should not change after stopping updater")
+}
+
 func Benchmark_CalculateTimestamp(b *testing.B) {
 	var res uint32
 	StartTimeStampUpdater()

--- a/time_test.go
+++ b/time_test.go
@@ -38,9 +38,8 @@ func Test_StopTimeStampUpdater(t *testing.T) {
 	// Capture the timestamp after stopping
 	stoppedTime := Timestamp()
 
-	// Wait TO see if it updates
+	// Wait before checking the timestamp
 	time.Sleep(5 * time.Second)
-
 	// It should not have changed since we've stopped the updater
 	require.Equal(t, stoppedTime, Timestamp(), "timestamp should not change after stopping updater")
 }

--- a/time_test.go
+++ b/time_test.go
@@ -32,21 +32,14 @@ func Test_StopTimeStampUpdater(t *testing.T) {
 	// Start the timestamp updater
 	StartTimeStampUpdater()
 
-	now := uint32(time.Now().Unix())
-	checkTimeStamp(t, now, Timestamp())
-
-	// Wait for an increment
-	time.Sleep(1 * time.Second)
-	checkTimeStamp(t, now+1, Timestamp())
-
 	// Stop the updater
 	StopTimeStampUpdater()
 
 	// Capture the timestamp after stopping
 	stoppedTime := Timestamp()
 
-	// Wait again to see if it updates
-	time.Sleep(3 * time.Second)
+	// Wait TO see if it updates
+	time.Sleep(5 * time.Second)
 
 	// It should not have changed since we've stopped the updater
 	require.Equal(t, stoppedTime, Timestamp(), "timestamp should not change after stopping updater")


### PR DESCRIPTION
- Add support for stopping a timestamp updater.

Fixes #69 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a mechanism to gracefully stop the timestamp updater.
	- Added a function to signal the timestamp updater to stop.

- **Bug Fixes**
	- Enhanced control flow to prevent potential goroutine leaks.

- **Tests**
	- Added a new test to validate the behavior of the timestamp updater when stopped, ensuring it does not increment after being signaled to stop.
	- Updated existing tests to improve execution context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->