### PR TITLE
🧹 chore: Add support for go1.24, and drop go1.22

### DIFF
--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -10,12 +10,13 @@ permissions:
   pull-requests: write
   statuses: write
   checks: write
+
 jobs:
-    labeler:
-        runs-on: ubuntu-latest
-        steps:
-            -   name: Check Labels
-                id: labeler
-                uses: fuxingloh/multi-labeler@v4
-                with:
-                    github-token: ${{secrets.GITHUB_TOKEN}}
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Labels
+        id: labeler
+        uses: fuxingloh/multi-labeler@v4
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           # NOTE: Keep this in sync with the version from go.mod
-          go-version: "1.22.x"
+          go-version: "1.23.x"
 
       - name: Run Benchmark
         run: set -o pipefail; go test ./... -benchmem -run=^$ -bench . | tee output.txt

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           # NOTE: Keep this in sync with the version from go.mod
-          go-version: "1.22.x"
+          go-version: "1.23.x"
           cache: false
 
       - name: golangci-lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
   Build:
     strategy:
       matrix:
-        go-version: [1.22.x, 1.23.x]
+        go-version: [1.23.x, 1.24.x]
         platform: [ubuntu-latest, windows-latest, macos-latest, macos-13]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -40,8 +40,8 @@ jobs:
         run: gotestsum -f testname -- ./... -race -count=1 -coverprofile=coverage.txt -covermode=atomic -shuffle=on
 
       - name: Upload coverage reports to Codecov
-        if: ${{ matrix.platform == 'ubuntu-latest' && matrix.go-version == '1.23.x' }}
-        uses: codecov/codecov-action@v5.3.1
+        if: ${{ matrix.platform == 'ubuntu-latest' && matrix.go-version == '1.24.x' }}
+        uses: codecov/codecov-action@v5.4.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.txt

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gofiber/utils/v2
 
-go 1.22
+go 1.23.0
 
 require (
 	github.com/fxamacker/cbor/v2 v2.7.0


### PR DESCRIPTION
- Add support for go1.24
- Drop support for go1.22
- Mark go1.23.0 as min version (Matches gofiber/fiber)

Closes https://github.com/gofiber/utils/pull/107