### PR TITLE
feat: Support case-insensitive parsing of Content Type

### DIFF
--- a/http.go
+++ b/http.go
@@ -70,10 +70,7 @@ func ParseVendorSpecificContentType(cType string, caseInsensitive ...bool) strin
 		return cType
 	}
 
-	if useLower {
-		return working[0:slashIndex+1] + parsableType
-	}
-	return cType[0:slashIndex+1] + parsableType
+	return working[0:slashIndex+1] + parsableType
 }
 
 // limits for HTTP statuscodes

--- a/http.go
+++ b/http.go
@@ -40,28 +40,39 @@ func GetMIME(extension string) string {
 // ParseVendorSpecificContentType check if content type is vendor specific and
 // if it is parsable to any known types. If its not vendor specific then returns
 // the original content type.
-func ParseVendorSpecificContentType(cType string) string {
-	plusIndex := strings.IndexByte(cType, '+')
+func ParseVendorSpecificContentType(cType string, caseInsensitive ...bool) string {
+	useLower := len(caseInsensitive) > 0 && caseInsensitive[0]
+
+	working := cType
+	if useLower {
+		// Content types are case-insensitive. Normalize if requested using the
+		// utils.ToLower function to avoid allocations when possible.
+		working = ToLower(cType)
+	}
+	plusIndex := strings.IndexByte(working, '+')
 
 	if plusIndex == -1 {
 		return cType
 	}
 
 	var parsableType string
-	if semiColonIndex := strings.IndexByte(cType, ';'); semiColonIndex == -1 {
-		parsableType = cType[plusIndex+1:]
+	if semiColonIndex := strings.IndexByte(working, ';'); semiColonIndex == -1 {
+		parsableType = working[plusIndex+1:]
 	} else if plusIndex < semiColonIndex {
-		parsableType = cType[plusIndex+1 : semiColonIndex]
+		parsableType = working[plusIndex+1 : semiColonIndex]
 	} else {
 		return cType[:semiColonIndex]
 	}
 
-	slashIndex := strings.IndexByte(cType, '/')
+	slashIndex := strings.IndexByte(working, '/')
 
 	if slashIndex == -1 {
 		return cType
 	}
 
+	if useLower {
+		return working[0:slashIndex+1] + parsableType
+	}
 	return cType[0:slashIndex+1] + parsableType
 }
 

--- a/http_test.go
+++ b/http_test.go
@@ -125,6 +125,14 @@ func Test_ParseVendorSpecificContentType(t *testing.T) {
 	cType = ParseVendorSpecificContentType("application/vnd.api+json")
 	require.Equal(t, "application/json", cType)
 
+	// Uppercase vendor specific type should only be parsed when case-insensitive
+	// matching is enabled
+	cType = ParseVendorSpecificContentType("APPLICATION/VND.API+JSON")
+	require.Equal(t, "APPLICATION/JSON", cType)
+
+	cType = ParseVendorSpecificContentType("APPLICATION/VND.API+JSON", true)
+	require.Equal(t, "application/json", cType)
+
 	cType = ParseVendorSpecificContentType("application/vnd.dummy+x-www-form-urlencoded")
 	require.Equal(t, "application/x-www-form-urlencoded", cType)
 


### PR DESCRIPTION
## Summary
- handle uppercase characters in `ParseVendorSpecificContentType`
- add a regression test for the uppercase scenario
- allow optional case-insensitive parsing controlled by an argument

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for optional case-insensitive parsing of vendor-specific content types.

* **Tests**
  * Expanded test coverage to verify correct handling of case-insensitive parsing, including uppercase input scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->