### PR TITLE
Improve ConvertToBytes performance

### DIFF
--- a/common.go
+++ b/common.go
@@ -30,11 +30,9 @@ const (
 // All rights reserved.
 
 var (
-	uuidSeed        [24]byte
-	uuidCounter     uint64
-	uuidSetup       sync.Once
-	unitsSlice      = []byte("kmgtp")
-	sizeMultipliers = [...]float64{1e3, 1e6, 1e9, 1e12, 1e15}
+	uuidSeed    [24]byte
+	uuidCounter uint64
+	uuidSetup   sync.Once
 )
 
 // UUID generates an universally unique identifier (UUID)

--- a/common.go
+++ b/common.go
@@ -127,7 +127,7 @@ func ConvertToBytes(humanReadableString string) int {
 			lastNumberPos = i
 			break
 		}
-		if c != ' ' {
+		if c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' {
 			unitPrefixPos = i
 		}
 	}
@@ -142,23 +142,23 @@ func ConvertToBytes(humanReadableString string) int {
 		}
 	} else {
 		i64, err := strconv.ParseUint(numPart, 10, 64)
-		if err != nil || i64 > uint64(^0) {
+		if err != nil {
 			return 0
 		}
 		size = float64(i64)
 	}
 
 	if unitPrefixPos > 0 {
-		switch toLowerTable[humanReadableString[unitPrefixPos]] {
-		case 'k':
+		switch humanReadableString[unitPrefixPos] {
+		case 'k', 'K':
 			size *= 1e3
-		case 'm':
+		case 'm', 'M':
 			size *= 1e6
-		case 'g':
+		case 'g', 'G':
 			size *= 1e9
-		case 't':
+		case 't', 'T':
 			size *= 1e12
-		case 'p':
+		case 'p', 'P':
 			size *= 1e15
 		}
 	}

--- a/common.go
+++ b/common.go
@@ -142,7 +142,7 @@ func ConvertToBytes(humanReadableString string) int {
 		}
 	} else {
 		i64, err := strconv.ParseUint(numPart, 10, 64)
-		if err != nil {
+		if err != nil || i64 > uint64(^0) {
 			return 0
 		}
 		size = float64(i64)

--- a/common.go
+++ b/common.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"encoding/hex"
+	"math"
 	"net"
 	"os"
 	"reflect"
@@ -163,8 +164,9 @@ func ConvertToBytes(humanReadableString string) int {
 		}
 	}
 
-	if size > float64(^uint(0)>>1) {
-		return int(^uint(0) >> 1)
+	if size > float64(math.MaxInt) {
+		return math.MaxInt
 	}
+
 	return int(size)
 }

--- a/common_test.go
+++ b/common_test.go
@@ -132,6 +132,7 @@ func Test_ConvertToBytes(t *testing.T) {
 	require.Equal(t, 0, ConvertToBytes("MB"))
 	require.Equal(t, 0, ConvertToBytes("invalidunit"))
 	require.Equal(t, 42, ConvertToBytes("42X"))     // invalid unit
+	require.Equal(t, 123, ConvertToBytes("123a k")) // invalid unit
 	require.Equal(t, 0, ConvertToBytes("42.5.5MB")) // invalid format
 
 	// Test decimal numbers with various units


### PR DESCRIPTION
## Summary
- optimize numeric parsing in `ConvertToBytes`
- replace map lookup with switch for unit multiplier

## Testing
- `go vet ./...`
- `go test ./...`
- `go test -bench=Benchmark_ConvertToBytes -benchmem -run=^$ ./...`

------
https://chatgpt.com/codex/tasks/task_e_686e194510148326b750eb06787f7f5e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling and parsing of size strings with unit suffixes (e.g., KB, MB, GB, etc.) for more accurate conversions.

* **Refactor**
  * Enhanced internal logic for interpreting numeric and unit parts of size strings, resulting in more reliable and consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->