### PR TITLE
Add optimized ParseUint

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ Benchmark_CalculateTimestamp/fiber-12        1000000000       0.2634 ns/op      
 Benchmark_CalculateTimestamp/fiber-12        1000000000       0.2935 ns/op       0 B/op       0 allocs/op
 Benchmark_CalculateTimestamp/default-12        15740576        73.79 ns/op       0 B/op       0 allocs/op
 Benchmark_CalculateTimestamp/default-12        15789036        71.12 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint-5           64891596                18.20 ns/op            0 B/op          0 allocs/op
+Benchmark_ParseUint-5           68725321                17.72 ns/op            0 B/op          0 allocs/op
+Benchmark_StdParseUint-5        43620374                28.53 ns/op            0 B/op          0 allocs/op
+Benchmark_StdParseUint-5        42279746                30.02 ns/op            0 B/op          0 allocs/op
 
 ```
 

--- a/numbers.go
+++ b/numbers.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"strconv"
+)
+
+const (
+	maxUint64      = ^uint64(0)
+	maxUint64Div10 = maxUint64 / 10
+	maxUint64Mod10 = maxUint64 % 10
+)
+
+// ParseUint parses a decimal ASCII representation of an unsigned integer.
+// It returns an error if the input contains non-digit characters or
+// the value overflows uint64.
+func ParseUint[S ~string | ~[]byte](s S) (uint64, error) {
+	if len(s) == 0 {
+		return 0, strconv.ErrSyntax
+	}
+	var n uint64
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c < '0' || c > '9' {
+			return 0, strconv.ErrSyntax
+		}
+		if n > maxUint64Div10 || (n == maxUint64Div10 && uint64(c-'0') > maxUint64Mod10) {
+			return 0, strconv.ErrRange
+		}
+		n = n*10 + uint64(c-'0')
+	}
+	return n, nil
+}

--- a/numbers_test.go
+++ b/numbers_test.go
@@ -1,0 +1,67 @@
+package utils
+
+import (
+	"math"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ParseUint(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   string
+		want uint64
+		err  error
+	}{
+		{"0", 0, nil},
+		{"42", 42, nil},
+		{"18446744073709551615", math.MaxUint64, nil},
+		{"", 0, strconv.ErrSyntax},
+		{"123abc", 0, strconv.ErrSyntax},
+		{"18446744073709551616", 0, strconv.ErrRange},
+		{"-1", 0, strconv.ErrSyntax},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.in, func(t *testing.T) {
+			v, err := ParseUint(tc.in)
+			if tc.err != nil {
+				require.ErrorIs(t, err, tc.err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.want, v)
+			}
+		})
+		t.Run(tc.in+"_bytes", func(t *testing.T) {
+			v, err := ParseUint([]byte(tc.in))
+			if tc.err != nil {
+				require.ErrorIs(t, err, tc.err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.want, v)
+			}
+		})
+	}
+}
+
+func Benchmark_ParseUint(b *testing.B) {
+	str := "1234567890"
+	var res uint64
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		res, _ = ParseUint(str)
+	}
+	require.Equal(b, uint64(1234567890), res)
+}
+
+func Benchmark_StdParseUint(b *testing.B) {
+	str := "1234567890"
+	var res uint64
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		res, _ = strconv.ParseUint(str, 10, 64)
+	}
+	require.Equal(b, uint64(1234567890), res)
+}


### PR DESCRIPTION
## Summary
- add `ParseUint` for parsing unsigned integers faster than `strconv.ParseUint`
- benchmark new function vs standard library
- document results in README

## Testing
- `go test ./... -run . -count=1`
- `go test ./... -bench=ParseUint -benchmem -run=^$ -count=2`

------
https://chatgpt.com/codex/tasks/task_e_686e19a07664832684ed066f531079c6