### PR TITLE
add parse functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,47 @@ Benchmark_CalculateTimestamp/fiber-12        1000000000       0.2935 ns/op      
 Benchmark_CalculateTimestamp/default-12        15740576        73.79 ns/op       0 B/op       0 allocs/op
 Benchmark_CalculateTimestamp/default-12        15789036        71.12 ns/op       0 B/op       0 allocs/op
 
+Benchmark_ParseUint/fiber-12                  209572438	       5.672 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint/fiber-12                  212094278	       5.682 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint/fiber_bytes-12            200529103	       6.262 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint/fiber_bytes-12            197217249	       6.091 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint/default-12                 88270990	       13.52 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint/default-12                 87889551	       14.00 ns/op       0 B/op       0 allocs/op
+
+Benchmark_ParseInt/fiber-12                   193843164	       6.244 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt/fiber-12                   195593282	       6.140 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt/fiber_bytes-12             183129720	       6.612 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt/fiber_bytes-12             187644654	       6.448 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt/default-12                  73799979	       16.24 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt/default-12                  72953503	       15.72 ns/op       0 B/op       0 allocs/op
+
+Benchmark_ParseInt32/fiber-12                 196407849	       6.218 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt32/fiber-12                 195812016	       6.128 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt32/fiber_bytes-12           186374653	       6.557 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt32/fiber_bytes-12           187143706	       6.468 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt32/default-12                76141933	       15.75 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt32/default-12                72576800	       15.78 ns/op       0 B/op       0 allocs/op
+
+Benchmark_ParseInt8/fiber-12                  293566040	       4.066 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt8/fiber-12                  295747276	       4.078 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt8/fiber_bytes-12            278629872	       4.355 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt8/fiber_bytes-12            277536484	       4.220 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt8/default-12                138617029	       8.628 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt8/default-12                138377208	       8.767 ns/op       0 B/op       0 allocs/op
+
+Benchmark_ParseUint32/fiber-12                211904874	       5.703 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint32/fiber-12                209829583	       5.634 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint32/fiber_bytes-12          198637155	       6.118 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint32/fiber_bytes-12          201367761	       5.994 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint32/default-12               85329795	       13.67 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint32/default-12               87421878	       13.68 ns/op       0 B/op       0 allocs/op
+
+Benchmark_ParseUint8/fiber-12                 550520269	       2.182 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint8/fiber-12                 560078643	       2.121 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint8/fiber_bytes-12           488134600	       2.523 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint8/fiber_bytes-12           498258688	       2.451 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint8/default-12               184652006	       6.580 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint8/default-12               182021036	       6.619 ns/op       0 B/op       0 allocs/op
 ```
 
 See all the benchmarks under <https://gofiber.github.io/utils/>

--- a/README.md
+++ b/README.md
@@ -135,47 +135,47 @@ Benchmark_CalculateTimestamp/fiber-12        1000000000       0.2935 ns/op      
 Benchmark_CalculateTimestamp/default-12        15740576        73.79 ns/op       0 B/op       0 allocs/op
 Benchmark_CalculateTimestamp/default-12        15789036        71.12 ns/op       0 B/op       0 allocs/op
 
-Benchmark_ParseUint/fiber-12                  209572438	       5.672 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseUint/fiber-12                  212094278	       5.682 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseUint/fiber_bytes-12            200529103	       6.262 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseUint/fiber_bytes-12            197217249	       6.091 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseUint/default-12                 88270990	       13.52 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseUint/default-12                 87889551	       14.00 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint/fiber-12                  190390941	       6.292 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint/fiber-12                  187968758	       6.400 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint/fiber_bytes-12            181957326	       6.809 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint/fiber_bytes-12            182275550	       6.558 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint/default-12                 88281543	       13.52 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint/default-12                 88967146	       13.41 ns/op       0 B/op       0 allocs/op
 
-Benchmark_ParseInt/fiber-12                   193843164	       6.244 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseInt/fiber-12                   195593282	       6.140 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseInt/fiber_bytes-12             183129720	       6.612 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseInt/fiber_bytes-12             187644654	       6.448 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseInt/default-12                  73799979	       16.24 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseInt/default-12                  72953503	       15.72 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt/fiber-12                   181353142	       6.723 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt/fiber-12                   180631305	       6.578 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt/fiber_bytes-12             175220041	       6.892 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt/fiber_bytes-12             171838354	       7.020 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt/default-12                  76055068	       15.77 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt/default-12                  75963992	       15.55 ns/op       0 B/op       0 allocs/op
 
-Benchmark_ParseInt32/fiber-12                 196407849	       6.218 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseInt32/fiber-12                 195812016	       6.128 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseInt32/fiber_bytes-12           186374653	       6.557 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseInt32/fiber_bytes-12           187143706	       6.468 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseInt32/default-12                76141933	       15.75 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseInt32/default-12                72576800	       15.78 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt32/fiber-12                 179962680	       6.631 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt32/fiber-12                 181285437	       6.570 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt32/fiber_bytes-12           173786900	       6.901 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt32/fiber_bytes-12           171283489	       7.069 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt32/default-12                69845103	       15.75 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt32/default-12                76438194	       15.66 ns/op       0 B/op       0 allocs/op
 
-Benchmark_ParseInt8/fiber-12                  293566040	       4.066 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseInt8/fiber-12                  295747276	       4.078 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseInt8/fiber_bytes-12            278629872	       4.355 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseInt8/fiber_bytes-12            277536484	       4.220 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseInt8/default-12                138617029	       8.628 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseInt8/default-12                138377208	       8.767 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt8/fiber-12                  286492362	       4.148 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt8/fiber-12                  282957276	       4.147 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt8/fiber_bytes-12            270179119	       4.481 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt8/fiber_bytes-12            258238294	       4.522 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt8/default-12                135063286	       8.831 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt8/default-12                140703313	       8.528 ns/op       0 B/op       0 allocs/op
 
-Benchmark_ParseUint32/fiber-12                211904874	       5.703 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseUint32/fiber-12                209829583	       5.634 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseUint32/fiber_bytes-12          198637155	       6.118 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseUint32/fiber_bytes-12          201367761	       5.994 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseUint32/default-12               85329795	       13.67 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseUint32/default-12               87421878	       13.68 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint32/fiber-12                184411585	       6.568 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint32/fiber-12                184338627	       6.543 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint32/fiber_bytes-12          178475793	       6.759 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint32/fiber_bytes-12          178517788	       7.052 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint32/default-12               83775481	       13.41 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint32/default-12               88117585	       13.51 ns/op       0 B/op       0 allocs/op
 
-Benchmark_ParseUint8/fiber-12                 550520269	       2.182 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseUint8/fiber-12                 560078643	       2.121 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseUint8/fiber_bytes-12           488134600	       2.523 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseUint8/fiber_bytes-12           498258688	       2.451 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseUint8/default-12               184652006	       6.580 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseUint8/default-12               182021036	       6.619 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint8/fiber-12                 401799110	       3.046 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint8/fiber-12                 380578648	       3.036 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint8/fiber_bytes-12           363442573	       3.344 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint8/fiber_bytes-12           357869246	       3.346 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint8/default-12               184238403	       6.788 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint8/default-12               186525054	       6.454 ns/op       0 B/op       0 allocs/op
 ```
 
 See all the benchmarks under <https://gofiber.github.io/utils/>

--- a/parse.go
+++ b/parse.go
@@ -1,0 +1,106 @@
+package utils
+
+import "math"
+
+type Signed interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64
+}
+type Unsigned interface {
+	~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}
+
+// ParseUint parses a decimal ASCII string or byte slice into a uint64.
+// It returns the parsed value and true on success.
+// If the input contains non-digit characters, it returns 0 and false.
+func ParseUint[S byteSeq](s S) (uint64, bool) {
+	return parseUnsigned[S, uint64](s, uint64(math.MaxUint64))
+}
+
+// ParseInt parses a decimal ASCII string or byte slice into an int64.
+// Returns the parsed value and true on success, else 0 and false.
+func ParseInt[S byteSeq](s S) (int64, bool) {
+	return parseSigned[S, int64](s, math.MinInt64, math.MaxInt64)
+}
+
+// ParseInt32 parses a decimal ASCII string or byte slice into an int32.
+func ParseInt32[S byteSeq](s S) (int32, bool) {
+	return parseSigned[S, int32](s, math.MinInt32, math.MaxInt32)
+}
+
+// ParseInt8 parses a decimal ASCII string or byte slice into an int8.
+func ParseInt8[S byteSeq](s S) (int8, bool) {
+	return parseSigned[S, int8](s, math.MinInt8, math.MaxInt8)
+}
+
+// ParseUint32 parses a decimal ASCII string or byte slice into a uint32.
+func ParseUint32[S byteSeq](s S) (uint32, bool) {
+	return parseUnsigned[S, uint32](s, uint32(math.MaxUint32))
+}
+
+// ParseUint8 parses a decimal ASCII string or byte slice into a uint8.
+func ParseUint8[S byteSeq](s S) (uint8, bool) {
+	return parseUnsigned[S, uint8](s, uint8(math.MaxUint8))
+}
+
+func parseSigned[S byteSeq, T Signed](s S, min, max T) (T, bool) {
+	if len(s) == 0 {
+		return 0, false
+	}
+	neg := false
+	i := 0
+	switch s[0] {
+	case '-':
+		neg = true
+		i++
+	case '+':
+		i++
+	}
+	if i == len(s) {
+		return 0, false
+	}
+
+	var n T
+	for ; i < len(s); i++ {
+		c := s[i]
+		if c < '0' || c > '9' {
+			return 0, false
+		}
+		d := T(c - '0')
+
+		if !neg {
+			if n > (max-d)/10 {
+				return 0, false
+			}
+			n = n*10 + d
+		} else {
+			if n < (min+d)/10 {
+				return 0, false
+			}
+			n = n*10 - d
+		}
+	}
+	if n < min || n > max {
+		return 0, false
+	}
+	return n, true
+}
+
+func parseUnsigned[S byteSeq, T Unsigned](s S, max T) (T, bool) {
+	if len(s) == 0 {
+		return 0, false
+	}
+	var n T
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c < '0' || c > '9' {
+			return 0, false
+		}
+		d := T(c - '0')
+		// Overflow check before multiplication and addition
+		if n > (max-d)/10 {
+			return 0, false
+		}
+		n = n*10 + d
+	}
+	return n, true
+}

--- a/parse.go
+++ b/parse.go
@@ -46,6 +46,7 @@ func parseSigned[S byteSeq, T Signed](s S, min, max T) (T, bool) {
 	if len(s) == 0 {
 		return 0, false
 	}
+
 	neg := false
 	i := 0
 	switch s[0] {
@@ -59,39 +60,32 @@ func parseSigned[S byteSeq, T Signed](s S, min, max T) (T, bool) {
 		return 0, false
 	}
 
-	if !neg {
-		cutoff := max / 10
-		rem := max - cutoff*10
-		var n T
-		for ; i < len(s); i++ {
-			c := s[i] - '0'
-			if c > 9 {
-				return 0, false
-			}
-			d := T(c)
-			if n > cutoff || (n == cutoff && d > rem) {
-				return 0, false
-			}
-			n = n*10 + d
-		}
-		return n, true
-	}
-
-	cutoff := min / 10
-	rem := -(min - cutoff*10)
-	var n T
+	var n uint64
 	for ; i < len(s); i++ {
 		c := s[i] - '0'
 		if c > 9 {
 			return 0, false
 		}
-		d := T(c)
-		if n < cutoff || (n == cutoff && d > rem) {
+		nn := n*10 + uint64(c)
+		if nn < n {
 			return 0, false
 		}
-		n = n*10 - d
+		n = nn
 	}
-	return n, true
+
+	if !neg {
+		if n > uint64(int64(max)) {
+			return 0, false
+		}
+		return T(n), true
+	}
+
+	minAbs := uint64(-int64(min))
+	if n > minAbs {
+		return 0, false
+	}
+
+	return T(-int64(n)), true
 }
 
 func parseUnsigned[S byteSeq, T Unsigned](s S, max T) (T, bool) {

--- a/parse.go
+++ b/parse.go
@@ -59,6 +59,11 @@ func parseSigned[S byteSeq, T Signed](s S, min, max T) (T, bool) {
 		return 0, false
 	}
 
+	maxCutoff := max / 10
+	maxRem := max - maxCutoff*10
+	minCutoff := min / 10
+	minRem := -(min - minCutoff*10)
+
 	var n T
 	for ; i < len(s); i++ {
 		c := s[i]
@@ -68,19 +73,16 @@ func parseSigned[S byteSeq, T Signed](s S, min, max T) (T, bool) {
 		d := T(c - '0')
 
 		if !neg {
-			if n > (max-d)/10 {
+			if n > maxCutoff || (n == maxCutoff && d > maxRem) {
 				return 0, false
 			}
 			n = n*10 + d
 		} else {
-			if n < (min+d)/10 {
+			if n < minCutoff || (n == minCutoff && d > minRem) {
 				return 0, false
 			}
 			n = n*10 - d
 		}
-	}
-	if n < min || n > max {
-		return 0, false
 	}
 	return n, true
 }
@@ -89,6 +91,8 @@ func parseUnsigned[S byteSeq, T Unsigned](s S, max T) (T, bool) {
 	if len(s) == 0 {
 		return 0, false
 	}
+	cutoff := max / 10
+	maxRem := max - cutoff*10
 	var n T
 	for i := 0; i < len(s); i++ {
 		c := s[i]
@@ -96,8 +100,7 @@ func parseUnsigned[S byteSeq, T Unsigned](s S, max T) (T, bool) {
 			return 0, false
 		}
 		d := T(c - '0')
-		// Overflow check before multiplication and addition
-		if n > (max-d)/10 {
+		if n > cutoff || (n == cutoff && d > maxRem) {
 			return 0, false
 		}
 		n = n*10 + d

--- a/parse.go
+++ b/parse.go
@@ -1,6 +1,8 @@
 package utils
 
-import "math"
+import (
+	"math"
+)
 
 type Signed interface {
 	~int | ~int8 | ~int16 | ~int32 | ~int64
@@ -62,7 +64,7 @@ func parseDigits[S byteSeq](s S, i int) (uint64, bool) {
 
 // parseSigned parses a decimal ASCII string or byte slice into a signed integer type T.
 // It supports optional '+' or '-' prefix, checks for overflow and underflow, and returns (0, false) on error.
-func parseSigned[S byteSeq, T Signed](s S, min, max T) (T, bool) {
+func parseSigned[S byteSeq, T Signed](s S, minRange, maxRange T) (T, bool) {
 	if len(s) == 0 {
 		return 0, false
 	}
@@ -88,14 +90,14 @@ func parseSigned[S byteSeq, T Signed](s S, min, max T) (T, bool) {
 
 	if !neg {
 		// Check for overflow
-		if n > uint64(int64(max)) {
+		if n > uint64(int64(maxRange)) {
 			return 0, false
 		}
 		return T(n), true
 	}
 
 	// Check for underflow
-	minAbs := uint64(-int64(min))
+	minAbs := uint64(-int64(minRange))
 	if n > minAbs {
 		return 0, false
 	}
@@ -105,7 +107,7 @@ func parseSigned[S byteSeq, T Signed](s S, min, max T) (T, bool) {
 
 // parseUnsigned parses a decimal ASCII string or byte slice into an unsigned integer type T.
 // It does not support sign prefixes, checks for overflow, and returns (0, false) on error.
-func parseUnsigned[S byteSeq, T Unsigned](s S, max T) (T, bool) {
+func parseUnsigned[S byteSeq, T Unsigned](s S, maxRange T) (T, bool) {
 	if len(s) == 0 {
 		return 0, false
 	}
@@ -115,7 +117,7 @@ func parseUnsigned[S byteSeq, T Unsigned](s S, max T) (T, bool) {
 	// Parse digits
 	n, ok := parseDigits(s, i)
 	// Check for overflow
-	if !ok || n > uint64(max) {
+	if !ok || n > uint64(maxRange) {
 		return 0, false
 	}
 	return T(n), true

--- a/parse.go
+++ b/parse.go
@@ -94,19 +94,23 @@ func parseUnsigned[S byteSeq, T Unsigned](s S, max T) (T, bool) {
 	}
 
 	i := 0
-	cutoff := max / 10
-	rem := max - cutoff*10
-	var n T
+
+	var n uint64
 	for ; i < len(s); i++ {
 		c := s[i] - '0'
 		if c > 9 {
 			return 0, false
 		}
-		d := T(c)
-		if n > cutoff || (n == cutoff && d > rem) {
+		nn := n*10 + uint64(c)
+		if nn < n {
 			return 0, false
 		}
-		n = n*10 + d
+		n = nn
 	}
-	return n, true
+
+	if n > uint64(max) {
+		return 0, false
+	}
+
+	return T(n), true
 }

--- a/parse.go
+++ b/parse.go
@@ -59,30 +59,37 @@ func parseSigned[S byteSeq, T Signed](s S, min, max T) (T, bool) {
 		return 0, false
 	}
 
-	maxCutoff := max / 10
-	maxRem := max - maxCutoff*10
-	minCutoff := min / 10
-	minRem := -(min - minCutoff*10)
-
-	var n T
-	for ; i < len(s); i++ {
-		c := s[i]
-		if c < '0' || c > '9' {
-			return 0, false
-		}
-		d := T(c - '0')
-
-		if !neg {
-			if n > maxCutoff || (n == maxCutoff && d > maxRem) {
+	if !neg {
+		cutoff := max / 10
+		rem := max - cutoff*10
+		var n T
+		for ; i < len(s); i++ {
+			c := s[i] - '0'
+			if c > 9 {
+				return 0, false
+			}
+			d := T(c)
+			if n > cutoff || (n == cutoff && d > rem) {
 				return 0, false
 			}
 			n = n*10 + d
-		} else {
-			if n < minCutoff || (n == minCutoff && d > minRem) {
-				return 0, false
-			}
-			n = n*10 - d
 		}
+		return n, true
+	}
+
+	cutoff := min / 10
+	rem := -(min - cutoff*10)
+	var n T
+	for ; i < len(s); i++ {
+		c := s[i] - '0'
+		if c > 9 {
+			return 0, false
+		}
+		d := T(c)
+		if n < cutoff || (n == cutoff && d > rem) {
+			return 0, false
+		}
+		n = n*10 - d
 	}
 	return n, true
 }
@@ -91,16 +98,18 @@ func parseUnsigned[S byteSeq, T Unsigned](s S, max T) (T, bool) {
 	if len(s) == 0 {
 		return 0, false
 	}
+
+	i := 0
 	cutoff := max / 10
-	maxRem := max - cutoff*10
+	rem := max - cutoff*10
 	var n T
-	for i := 0; i < len(s); i++ {
-		c := s[i]
-		if c < '0' || c > '9' {
+	for ; i < len(s); i++ {
+		c := s[i] - '0'
+		if c > 9 {
 			return 0, false
 		}
-		d := T(c - '0')
-		if n > cutoff || (n == cutoff && d > maxRem) {
+		d := T(c)
+		if n > cutoff || (n == cutoff && d > rem) {
 			return 0, false
 		}
 		n = n*10 + d

--- a/parse_test.go
+++ b/parse_test.go
@@ -95,6 +95,32 @@ func Test_ParseInt(t *testing.T) {
 	}
 }
 
+func Test_ParseInt_SignOnly(t *testing.T) {
+	t.Parallel()
+
+	tests := []string{"+", "-"}
+	for _, in := range tests {
+		v, ok := ParseInt(in)
+		require.False(t, ok)
+		require.Equal(t, int64(0), v)
+		b, ok := ParseInt([]byte(in))
+		require.False(t, ok)
+		require.Equal(t, int64(0), b)
+	}
+}
+
+func Test_ParseUnsigned_SignOnly(t *testing.T) {
+	t.Parallel()
+
+	in := "+"
+	v, ok := ParseUint(in)
+	require.False(t, ok)
+	require.Equal(t, uint64(0), v)
+	b, ok := ParseUint([]byte(in))
+	require.False(t, ok)
+	require.Equal(t, uint64(0), b)
+}
+
 func Benchmark_ParseInt(b *testing.B) {
 	input := "123456789"
 

--- a/parse_test.go
+++ b/parse_test.go
@@ -135,6 +135,7 @@ func Test_ParseInt32(t *testing.T) {
 		success bool
 	}{
 		{"0", 0, true},
+		{"42", 42, true},
 		{"2147483647", 2147483647, true},
 		{"-2147483648", -2147483648, true},
 		{"2147483648", 0, false},
@@ -194,6 +195,7 @@ func Test_ParseInt8(t *testing.T) {
 		success bool
 	}{
 		{"0", 0, true},
+		{"42", 42, true},
 		{"127", 127, true},
 		{"-128", -128, true},
 		{"128", 0, false},
@@ -253,6 +255,7 @@ func Test_ParseUint32(t *testing.T) {
 		success bool
 	}{
 		{"0", 0, true},
+		{"42", 42, true},
 		{"4294967295", 4294967295, true},
 		{"4294967296", 0, false},
 		{"-1", 0, false},
@@ -311,6 +314,7 @@ func Test_ParseUint8(t *testing.T) {
 		success bool
 	}{
 		{"0", 0, true},
+		{"42", 42, true},
 		{"255", 255, true},
 		{"256", 0, false},
 		{"-1", 0, false},

--- a/parse_test.go
+++ b/parse_test.go
@@ -37,15 +37,6 @@ func Test_ParseUint(t *testing.T) {
 func Benchmark_ParseUint(b *testing.B) {
 	input := "123456789"
 
-	b.Run("default", func(b *testing.B) {
-		b.ReportAllocs()
-		for n := 0; n < b.N; n++ {
-			_, err := strconv.ParseUint(input, 10, 64)
-			if err != nil {
-				b.Fatal(err)
-			}
-		}
-	})
 	b.Run("fiber", func(b *testing.B) {
 		b.ReportAllocs()
 		for n := 0; n < b.N; n++ {
@@ -61,6 +52,15 @@ func Benchmark_ParseUint(b *testing.B) {
 			_, ok := ParseUint([]byte(input))
 			if !ok {
 				b.Fatal("failed to parse uint from bytes")
+			}
+		}
+	})
+	b.Run("default", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			_, err := strconv.ParseUint(input, 10, 64)
+			if err != nil {
+				b.Fatal(err)
 			}
 		}
 	})
@@ -98,15 +98,6 @@ func Test_ParseInt(t *testing.T) {
 func Benchmark_ParseInt(b *testing.B) {
 	input := "123456789"
 
-	b.Run("default", func(b *testing.B) {
-		b.ReportAllocs()
-		for n := 0; n < b.N; n++ {
-			_, err := strconv.ParseInt(input, 10, 64)
-			if err != nil {
-				b.Fatal(err)
-			}
-		}
-	})
 	b.Run("fiber", func(b *testing.B) {
 		b.ReportAllocs()
 		for n := 0; n < b.N; n++ {
@@ -122,6 +113,15 @@ func Benchmark_ParseInt(b *testing.B) {
 			_, ok := ParseInt([]byte(input))
 			if !ok {
 				b.Fatal("failed to parse int from bytes")
+			}
+		}
+	})
+	b.Run("default", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			_, err := strconv.ParseInt(input, 10, 64)
+			if err != nil {
+				b.Fatal(err)
 			}
 		}
 	})
@@ -158,15 +158,6 @@ func Test_ParseInt32(t *testing.T) {
 func Benchmark_ParseInt32(b *testing.B) {
 	input := "123456789"
 
-	b.Run("default", func(b *testing.B) {
-		b.ReportAllocs()
-		for n := 0; n < b.N; n++ {
-			_, err := strconv.ParseInt(input, 10, 32)
-			if err != nil {
-				b.Fatal(err)
-			}
-		}
-	})
 	b.Run("fiber", func(b *testing.B) {
 		b.ReportAllocs()
 		for n := 0; n < b.N; n++ {
@@ -182,6 +173,15 @@ func Benchmark_ParseInt32(b *testing.B) {
 			_, ok := ParseInt32([]byte(input))
 			if !ok {
 				b.Fatal("failed to parse int32 from bytes")
+			}
+		}
+	})
+	b.Run("default", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			_, err := strconv.ParseInt(input, 10, 32)
+			if err != nil {
+				b.Fatal(err)
 			}
 		}
 	})
@@ -218,15 +218,6 @@ func Test_ParseInt8(t *testing.T) {
 func Benchmark_ParseInt8(b *testing.B) {
 	input := "127"
 
-	b.Run("default", func(b *testing.B) {
-		b.ReportAllocs()
-		for n := 0; n < b.N; n++ {
-			_, err := strconv.ParseInt(input, 10, 8)
-			if err != nil {
-				b.Fatal(err)
-			}
-		}
-	})
 	b.Run("fiber", func(b *testing.B) {
 		b.ReportAllocs()
 		for n := 0; n < b.N; n++ {
@@ -242,6 +233,15 @@ func Benchmark_ParseInt8(b *testing.B) {
 			_, ok := ParseInt8([]byte(input))
 			if !ok {
 				b.Fatal("failed to parse int8 from bytes")
+			}
+		}
+	})
+	b.Run("default", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			_, err := strconv.ParseInt(input, 10, 8)
+			if err != nil {
+				b.Fatal(err)
 			}
 		}
 	})
@@ -277,15 +277,6 @@ func Test_ParseUint32(t *testing.T) {
 func Benchmark_ParseUint32(b *testing.B) {
 	input := "123456789"
 
-	b.Run("default", func(b *testing.B) {
-		b.ReportAllocs()
-		for n := 0; n < b.N; n++ {
-			_, err := strconv.ParseUint(input, 10, 32)
-			if err != nil {
-				b.Fatal(err)
-			}
-		}
-	})
 	b.Run("fiber", func(b *testing.B) {
 		b.ReportAllocs()
 		for n := 0; n < b.N; n++ {
@@ -301,6 +292,15 @@ func Benchmark_ParseUint32(b *testing.B) {
 			_, ok := ParseUint32([]byte(input))
 			if !ok {
 				b.Fatal("failed to parse uint32 from bytes")
+			}
+		}
+	})
+	b.Run("default", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			_, err := strconv.ParseUint(input, 10, 32)
+			if err != nil {
+				b.Fatal(err)
 			}
 		}
 	})
@@ -336,15 +336,6 @@ func Test_ParseUint8(t *testing.T) {
 func Benchmark_ParseUint8(b *testing.B) {
 	input := "255"
 
-	b.Run("default", func(b *testing.B) {
-		b.ReportAllocs()
-		for n := 0; n < b.N; n++ {
-			_, err := strconv.ParseUint(input, 10, 8)
-			if err != nil {
-				b.Fatal(err)
-			}
-		}
-	})
 	b.Run("fiber", func(b *testing.B) {
 		b.ReportAllocs()
 		for n := 0; n < b.N; n++ {
@@ -360,6 +351,15 @@ func Benchmark_ParseUint8(b *testing.B) {
 			_, ok := ParseUint8([]byte(input))
 			if !ok {
 				b.Fatal("failed to parse uint8 from bytes")
+			}
+		}
+	})
+	b.Run("default", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			_, err := strconv.ParseUint(input, 10, 8)
+			if err != nil {
+				b.Fatal(err)
 			}
 		}
 	})

--- a/parse_test.go
+++ b/parse_test.go
@@ -1,0 +1,362 @@
+package utils
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ParseUint(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		in      string
+		val     uint64
+		success bool
+	}{
+		{"0", 0, true},
+		{"42", 42, true},
+		{"123456789", 123456789, true},
+		{"", 0, false},
+		{"12a", 0, false},
+	}
+	for _, tt := range tests {
+		v, ok := ParseUint(tt.in)
+		require.Equal(t, tt.success, ok)
+		if ok {
+			require.Equal(t, tt.val, v)
+		}
+		b, ok := ParseUint([]byte(tt.in))
+		require.Equal(t, tt.success, ok)
+		if ok {
+			require.Equal(t, tt.val, b)
+		}
+	}
+}
+
+func Benchmark_ParseUint(b *testing.B) {
+	input := "123456789"
+
+	b.Run("default", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			_, err := strconv.ParseUint(input, 10, 64)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("fiber", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			_, ok := ParseUint(input)
+			if !ok {
+				b.Fatal("failed to parse uint")
+			}
+		}
+	})
+	b.Run("fiber_bytes", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			_, ok := ParseUint([]byte(input))
+			if !ok {
+				b.Fatal("failed to parse uint from bytes")
+			}
+		}
+	})
+}
+
+func Test_ParseInt(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		in      string
+		val     int64
+		success bool
+	}{
+		{"0", 0, true},
+		{"42", 42, true},
+		{"-42", -42, true},
+		{"123456789", 123456789, true},
+		{"", 0, false},
+		{"12a", 0, false},
+		{"-", 0, false},
+	}
+	for _, tt := range tests {
+		v, ok := ParseInt(tt.in)
+		require.Equal(t, tt.success, ok)
+		if ok {
+			require.Equal(t, tt.val, v)
+		}
+		b, ok := ParseInt([]byte(tt.in))
+		require.Equal(t, tt.success, ok)
+		if ok {
+			require.Equal(t, tt.val, b)
+		}
+	}
+}
+
+func Benchmark_ParseInt(b *testing.B) {
+	input := "123456789"
+
+	b.Run("default", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			_, err := strconv.ParseInt(input, 10, 64)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("fiber", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			_, ok := ParseInt(input)
+			if !ok {
+				b.Fatal("failed to parse int")
+			}
+		}
+	})
+	b.Run("fiber_bytes", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			_, ok := ParseInt([]byte(input))
+			if !ok {
+				b.Fatal("failed to parse int from bytes")
+			}
+		}
+	})
+}
+
+func Test_ParseInt32(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		in      string
+		val     int32
+		success bool
+	}{
+		{"0", 0, true},
+		{"2147483647", 2147483647, true},
+		{"-2147483648", -2147483648, true},
+		{"2147483648", 0, false},
+		{"-2147483649", 0, false},
+	}
+	for _, tt := range tests {
+		v, ok := ParseInt32(tt.in)
+		require.Equal(t, tt.success, ok)
+		if ok {
+			require.Equal(t, tt.val, v)
+		}
+		b, ok := ParseInt32([]byte(tt.in))
+		require.Equal(t, tt.success, ok)
+		if ok {
+			require.Equal(t, tt.val, b)
+		}
+	}
+}
+
+func Benchmark_ParseInt32(b *testing.B) {
+	input := "123456789"
+
+	b.Run("default", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			_, err := strconv.ParseInt(input, 10, 32)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("fiber", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			_, ok := ParseInt32(input)
+			if !ok {
+				b.Fatal("failed to parse int32")
+			}
+		}
+	})
+	b.Run("fiber_bytes", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			_, ok := ParseInt32([]byte(input))
+			if !ok {
+				b.Fatal("failed to parse int32 from bytes")
+			}
+		}
+	})
+}
+
+func Test_ParseInt8(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		in      string
+		val     int8
+		success bool
+	}{
+		{"0", 0, true},
+		{"127", 127, true},
+		{"-128", -128, true},
+		{"128", 0, false},
+		{"-129", 0, false},
+	}
+	for _, tt := range tests {
+		v, ok := ParseInt8(tt.in)
+		require.Equal(t, tt.success, ok)
+		if ok {
+			require.Equal(t, tt.val, v)
+		}
+		b, ok := ParseInt8([]byte(tt.in))
+		require.Equal(t, tt.success, ok)
+		if ok {
+			require.Equal(t, tt.val, b)
+		}
+	}
+}
+
+func Benchmark_ParseInt8(b *testing.B) {
+	input := "127"
+
+	b.Run("default", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			_, err := strconv.ParseInt(input, 10, 8)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("fiber", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			_, ok := ParseInt8(input)
+			if !ok {
+				b.Fatal("failed to parse int8")
+			}
+		}
+	})
+	b.Run("fiber_bytes", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			_, ok := ParseInt8([]byte(input))
+			if !ok {
+				b.Fatal("failed to parse int8 from bytes")
+			}
+		}
+	})
+}
+
+func Test_ParseUint32(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		in      string
+		val     uint32
+		success bool
+	}{
+		{"0", 0, true},
+		{"4294967295", 4294967295, true},
+		{"4294967296", 0, false},
+		{"-1", 0, false},
+	}
+	for _, tt := range tests {
+		v, ok := ParseUint32(tt.in)
+		require.Equal(t, tt.success, ok)
+		if ok {
+			require.Equal(t, tt.val, v)
+		}
+		b, ok := ParseUint32([]byte(tt.in))
+		require.Equal(t, tt.success, ok)
+		if ok {
+			require.Equal(t, tt.val, b)
+		}
+	}
+}
+
+func Benchmark_ParseUint32(b *testing.B) {
+	input := "123456789"
+
+	b.Run("default", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			_, err := strconv.ParseUint(input, 10, 32)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("fiber", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			_, ok := ParseUint32(input)
+			if !ok {
+				b.Fatal("failed to parse uint32")
+			}
+		}
+	})
+	b.Run("fiber_bytes", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			_, ok := ParseUint32([]byte(input))
+			if !ok {
+				b.Fatal("failed to parse uint32 from bytes")
+			}
+		}
+	})
+}
+
+func Test_ParseUint8(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		in      string
+		val     uint8
+		success bool
+	}{
+		{"0", 0, true},
+		{"255", 255, true},
+		{"256", 0, false},
+		{"-1", 0, false},
+	}
+	for _, tt := range tests {
+		v, ok := ParseUint8(tt.in)
+		require.Equal(t, tt.success, ok)
+		if ok {
+			require.Equal(t, tt.val, v)
+		}
+		b, ok := ParseUint8([]byte(tt.in))
+		require.Equal(t, tt.success, ok)
+		if ok {
+			require.Equal(t, tt.val, b)
+		}
+	}
+}
+
+func Benchmark_ParseUint8(b *testing.B) {
+	input := "255"
+
+	b.Run("default", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			_, err := strconv.ParseUint(input, 10, 8)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("fiber", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			_, ok := ParseUint8(input)
+			if !ok {
+				b.Fatal("failed to parse uint8")
+			}
+		}
+	})
+	b.Run("fiber_bytes", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			_, ok := ParseUint8([]byte(input))
+			if !ok {
+				b.Fatal("failed to parse uint8 from bytes")
+			}
+		}
+	})
+}


### PR DESCRIPTION
```

Benchmark_ParseUint/fiber-12                  190390941	       6.292 ns/op       0 B/op       0 allocs/op
Benchmark_ParseUint/fiber-12                  187968758	       6.400 ns/op       0 B/op       0 allocs/op
Benchmark_ParseUint/fiber_bytes-12            181957326	       6.809 ns/op       0 B/op       0 allocs/op
Benchmark_ParseUint/fiber_bytes-12            182275550	       6.558 ns/op       0 B/op       0 allocs/op
Benchmark_ParseUint/default-12                 88281543	       13.52 ns/op       0 B/op       0 allocs/op
Benchmark_ParseUint/default-12                 88967146	       13.41 ns/op       0 B/op       0 allocs/op

Benchmark_ParseInt/fiber-12                   181353142	       6.723 ns/op       0 B/op       0 allocs/op
Benchmark_ParseInt/fiber-12                   180631305	       6.578 ns/op       0 B/op       0 allocs/op
Benchmark_ParseInt/fiber_bytes-12             175220041	       6.892 ns/op       0 B/op       0 allocs/op
Benchmark_ParseInt/fiber_bytes-12             171838354	       7.020 ns/op       0 B/op       0 allocs/op
Benchmark_ParseInt/default-12                  76055068	       15.77 ns/op       0 B/op       0 allocs/op
Benchmark_ParseInt/default-12                  75963992	       15.55 ns/op       0 B/op       0 allocs/op

Benchmark_ParseInt32/fiber-12                 179962680	       6.631 ns/op       0 B/op       0 allocs/op
Benchmark_ParseInt32/fiber-12                 181285437	       6.570 ns/op       0 B/op       0 allocs/op
Benchmark_ParseInt32/fiber_bytes-12           173786900	       6.901 ns/op       0 B/op       0 allocs/op
Benchmark_ParseInt32/fiber_bytes-12           171283489	       7.069 ns/op       0 B/op       0 allocs/op
Benchmark_ParseInt32/default-12                69845103	       15.75 ns/op       0 B/op       0 allocs/op
Benchmark_ParseInt32/default-12                76438194	       15.66 ns/op       0 B/op       0 allocs/op

Benchmark_ParseInt8/fiber-12                  286492362	       4.148 ns/op       0 B/op       0 allocs/op
Benchmark_ParseInt8/fiber-12                  282957276	       4.147 ns/op       0 B/op       0 allocs/op
Benchmark_ParseInt8/fiber_bytes-12            270179119	       4.481 ns/op       0 B/op       0 allocs/op
Benchmark_ParseInt8/fiber_bytes-12            258238294	       4.522 ns/op       0 B/op       0 allocs/op
Benchmark_ParseInt8/default-12                135063286	       8.831 ns/op       0 B/op       0 allocs/op
Benchmark_ParseInt8/default-12                140703313	       8.528 ns/op       0 B/op       0 allocs/op

Benchmark_ParseUint32/fiber-12                184411585	       6.568 ns/op       0 B/op       0 allocs/op
Benchmark_ParseUint32/fiber-12                184338627	       6.543 ns/op       0 B/op       0 allocs/op
Benchmark_ParseUint32/fiber_bytes-12          178475793	       6.759 ns/op       0 B/op       0 allocs/op
Benchmark_ParseUint32/fiber_bytes-12          178517788	       7.052 ns/op       0 B/op       0 allocs/op
Benchmark_ParseUint32/default-12               83775481	       13.41 ns/op       0 B/op       0 allocs/op
Benchmark_ParseUint32/default-12               88117585	       13.51 ns/op       0 B/op       0 allocs/op

Benchmark_ParseUint8/fiber-12                 401799110	       3.046 ns/op       0 B/op       0 allocs/op
Benchmark_ParseUint8/fiber-12                 380578648	       3.036 ns/op       0 B/op       0 allocs/op
Benchmark_ParseUint8/fiber_bytes-12           363442573	       3.344 ns/op       0 B/op       0 allocs/op
Benchmark_ParseUint8/fiber_bytes-12           357869246	       3.346 ns/op       0 B/op       0 allocs/op
Benchmark_ParseUint8/default-12               184238403	       6.788 ns/op       0 B/op       0 allocs/op
Benchmark_ParseUint8/default-12               186525054	       6.454 ns/op       0 B/op       0 allocs/op
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced new utilities for parsing strings and byte slices into various integer types, supporting both signed and unsigned formats.
* **Tests**
  * Added comprehensive unit tests and benchmarks to validate correctness and measure performance of the new parsing utilities.
* **Documentation**
  * Updated documentation with detailed benchmark results comparing the new parsing utilities to standard implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->