### PR TITLE
Add parse float

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,19 +177,19 @@ Benchmark_ParseUint8/fiber_bytes-12           357869246        3.346 ns/op      
 Benchmark_ParseUint8/default-12               184238403        6.788 ns/op       0 B/op       0 allocs/op
 Benchmark_ParseUint8/default-12               186525054        6.454 ns/op       0 B/op       0 allocs/op
 
-Benchmark_ParseFloat64/fiber-12               100000000        10.54 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseFloat64/fiber-12               100000000        10.53 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseFloat64/fiber_bytes-12         100000000        10.73 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseFloat64/fiber_bytes-12         100000000        10.70 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseFloat64/default-12              50287230        23.76 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseFloat64/default-12              50541388        23.63 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseFloat64/fiber-12               130381844        9.355 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseFloat64/fiber-12               129132879        9.170 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseFloat64/fiber_bytes-12         125142489        9.786 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseFloat64/fiber_bytes-12         125434107        9.617 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseFloat64/default-12              49301054        24.17 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseFloat64/default-12              48115717        24.16 ns/op       0 B/op       0 allocs/op
 
-Benchmark_ParseFloat32/fiber-12               100000000        11.72 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseFloat32/fiber-12               100000000        11.73 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseFloat32/fiber_bytes-12         100000000        11.59 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseFloat32/fiber_bytes-12         100000000        11.62 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseFloat32/default-12              46845721        25.06 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseFloat32/default-12              47179315        25.09 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseFloat32/fiber-12               100000000        10.11 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseFloat32/fiber-12               100000000        10.14 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseFloat32/fiber_bytes-12         100000000        10.44 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseFloat32/fiber_bytes-12         100000000        10.61 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseFloat32/default-12              46581891        25.97 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseFloat32/default-12              44455900        26.94 ns/op       0 B/op       0 allocs/op
 ```
 
 See all the benchmarks under <https://gofiber.github.io/utils/>

--- a/README.md
+++ b/README.md
@@ -177,12 +177,19 @@ Benchmark_ParseUint8/fiber_bytes-12           357869246        3.346 ns/op      
 Benchmark_ParseUint8/default-12               184238403        6.788 ns/op       0 B/op       0 allocs/op
 Benchmark_ParseUint8/default-12               186525054        6.454 ns/op       0 B/op       0 allocs/op
 
-Benchmark_ParseFloat/fiber-12                 100000000         11.18 ns/op      0 B/op       0 allocs/op
-Benchmark_ParseFloat/fiber-12                 100000000         10.98 ns/op      0 B/op       0 allocs/op
-Benchmark_ParseFloat/fiber_bytes-12           100000000         11.30 ns/op      0 B/op       0 allocs/op
-Benchmark_ParseFloat/fiber_bytes-12           100000000         11.33 ns/op      0 B/op       0 allocs/op
-Benchmark_ParseFloat/default-12                49387119         24.56 ns/op      0 B/op       0 allocs/op
-Benchmark_ParseFloat/default-12                50058313         24.14 ns/op      0 B/op       0 allocs/op
+Benchmark_ParseFloat64/fiber-12               100000000        10.54 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseFloat64/fiber-12               100000000        10.53 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseFloat64/fiber_bytes-12         100000000        10.73 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseFloat64/fiber_bytes-12         100000000        10.70 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseFloat64/default-12              50287230        23.76 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseFloat64/default-12              50541388        23.63 ns/op       0 B/op       0 allocs/op
+
+Benchmark_ParseFloat32/fiber-12               100000000        11.72 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseFloat32/fiber-12               100000000        11.73 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseFloat32/fiber_bytes-12         100000000        11.59 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseFloat32/fiber_bytes-12         100000000        11.62 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseFloat32/default-12              46845721        25.06 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseFloat32/default-12              47179315        25.09 ns/op       0 B/op       0 allocs/op
 ```
 
 See all the benchmarks under <https://gofiber.github.io/utils/>

--- a/README.md
+++ b/README.md
@@ -135,47 +135,54 @@ Benchmark_CalculateTimestamp/fiber-12        1000000000       0.2935 ns/op      
 Benchmark_CalculateTimestamp/default-12        15740576        73.79 ns/op       0 B/op       0 allocs/op
 Benchmark_CalculateTimestamp/default-12        15789036        71.12 ns/op       0 B/op       0 allocs/op
 
-Benchmark_ParseUint/fiber-12                  190390941	       6.292 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseUint/fiber-12                  187968758	       6.400 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseUint/fiber_bytes-12            181957326	       6.809 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseUint/fiber_bytes-12            182275550	       6.558 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseUint/default-12                 88281543	       13.52 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseUint/default-12                 88967146	       13.41 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint/fiber-12                  190390941        6.292 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint/fiber-12                  187968758        6.400 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint/fiber_bytes-12            181957326        6.809 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint/fiber_bytes-12            182275550        6.558 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint/default-12                 88281543        13.52 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint/default-12                 88967146        13.41 ns/op       0 B/op       0 allocs/op
 
-Benchmark_ParseInt/fiber-12                   181353142	       6.723 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseInt/fiber-12                   180631305	       6.578 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseInt/fiber_bytes-12             175220041	       6.892 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseInt/fiber_bytes-12             171838354	       7.020 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseInt/default-12                  76055068	       15.77 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseInt/default-12                  75963992	       15.55 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt/fiber-12                   181353142        6.723 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt/fiber-12                   180631305        6.578 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt/fiber_bytes-12             175220041        6.892 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt/fiber_bytes-12             171838354        7.020 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt/default-12                  76055068        15.77 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt/default-12                  75963992        15.55 ns/op       0 B/op       0 allocs/op
 
-Benchmark_ParseInt32/fiber-12                 179962680	       6.631 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseInt32/fiber-12                 181285437	       6.570 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseInt32/fiber_bytes-12           173786900	       6.901 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseInt32/fiber_bytes-12           171283489	       7.069 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseInt32/default-12                69845103	       15.75 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseInt32/default-12                76438194	       15.66 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt32/fiber-12                 179962680        6.631 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt32/fiber-12                 181285437        6.570 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt32/fiber_bytes-12           173786900        6.901 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt32/fiber_bytes-12           171283489        7.069 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt32/default-12                69845103        15.75 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt32/default-12                76438194        15.66 ns/op       0 B/op       0 allocs/op
 
-Benchmark_ParseInt8/fiber-12                  286492362	       4.148 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseInt8/fiber-12                  282957276	       4.147 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseInt8/fiber_bytes-12            270179119	       4.481 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseInt8/fiber_bytes-12            258238294	       4.522 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseInt8/default-12                135063286	       8.831 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseInt8/default-12                140703313	       8.528 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt8/fiber-12                  286492362        4.148 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt8/fiber-12                  282957276        4.147 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt8/fiber_bytes-12            270179119        4.481 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt8/fiber_bytes-12            258238294        4.522 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt8/default-12                135063286        8.831 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseInt8/default-12                140703313        8.528 ns/op       0 B/op       0 allocs/op
 
-Benchmark_ParseUint32/fiber-12                184411585	       6.568 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseUint32/fiber-12                184338627	       6.543 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseUint32/fiber_bytes-12          178475793	       6.759 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseUint32/fiber_bytes-12          178517788	       7.052 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseUint32/default-12               83775481	       13.41 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseUint32/default-12               88117585	       13.51 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint32/fiber-12                184411585        6.568 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint32/fiber-12                184338627        6.543 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint32/fiber_bytes-12          178475793        6.759 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint32/fiber_bytes-12          178517788        7.052 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint32/default-12               83775481        13.41 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint32/default-12               88117585        13.51 ns/op       0 B/op       0 allocs/op
 
-Benchmark_ParseUint8/fiber-12                 401799110	       3.046 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseUint8/fiber-12                 380578648	       3.036 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseUint8/fiber_bytes-12           363442573	       3.344 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseUint8/fiber_bytes-12           357869246	       3.346 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseUint8/default-12               184238403	       6.788 ns/op       0 B/op       0 allocs/op
-Benchmark_ParseUint8/default-12               186525054	       6.454 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint8/fiber-12                 401799110        3.046 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint8/fiber-12                 380578648        3.036 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint8/fiber_bytes-12           363442573        3.344 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint8/fiber_bytes-12           357869246        3.346 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint8/default-12               184238403        6.788 ns/op       0 B/op       0 allocs/op
+Benchmark_ParseUint8/default-12               186525054        6.454 ns/op       0 B/op       0 allocs/op
+
+Benchmark_ParseFloat/fiber-12                 100000000         11.18 ns/op      0 B/op       0 allocs/op
+Benchmark_ParseFloat/fiber-12                 100000000         10.98 ns/op      0 B/op       0 allocs/op
+Benchmark_ParseFloat/fiber_bytes-12           100000000         11.30 ns/op      0 B/op       0 allocs/op
+Benchmark_ParseFloat/fiber_bytes-12           100000000         11.33 ns/op      0 B/op       0 allocs/op
+Benchmark_ParseFloat/default-12                49387119         24.56 ns/op      0 B/op       0 allocs/op
+Benchmark_ParseFloat/default-12                50058313         24.14 ns/op      0 B/op       0 allocs/op
 ```
 
 See all the benchmarks under <https://gofiber.github.io/utils/>

--- a/parse.go
+++ b/parse.go
@@ -197,8 +197,11 @@ func parseFloat[S byteSeq](s S) (float64, bool) {
 				return 0, false
 			}
 			exp = exp*10 + int64(c)
-			if exp > 308 {
+			if !expSign && exp > 308 {
 				exp = 309
+			}
+			if expSign && exp > 324 {
+				exp = 325
 			}
 			i++
 		}

--- a/parse.go
+++ b/parse.go
@@ -123,9 +123,10 @@ func parseUnsigned[S byteSeq, T Unsigned](s S, maxRange T) (T, bool) {
 	return T(n), true
 }
 
-// ParseFloat parses a decimal ASCII string or byte slice into a float64.
-// Supports optional sign, fractional part and exponent. Returns (0, false) on error or overflow.
-func ParseFloat[S byteSeq](s S) (float64, bool) {
+// parseFloat parses a decimal ASCII string or byte slice into a float64.
+// It supports optional sign, fractional part and exponent. It returns (0, false)
+// on error or overflow.
+func parseFloat[S byteSeq](s S) (float64, bool) {
 	if len(s) == 0 {
 		return 0, false
 	}
@@ -224,4 +225,23 @@ func ParseFloat[S byteSeq](s S) (float64, bool) {
 		return 0, false
 	}
 	return f, true
+}
+
+// ParseFloat64 parses a decimal ASCII string or byte slice into a float64. It
+// delegates the actual parsing to parseFloat.
+func ParseFloat64[S byteSeq](s S) (float64, bool) {
+	return parseFloat[S](s)
+}
+
+// ParseFloat32 parses a decimal ASCII string or byte slice into a float32. It
+// returns (0, false) on error or if the parsed value overflows float32.
+func ParseFloat32[S byteSeq](s S) (float32, bool) {
+	f, ok := parseFloat[S](s)
+	if !ok {
+		return 0, false
+	}
+	if f > math.MaxFloat32 || f < -math.MaxFloat32 {
+		return 0, false
+	}
+	return float32(f), true
 }

--- a/parse.go
+++ b/parse.go
@@ -160,9 +160,6 @@ func ParseFloat[S byteSeq](s S) (float64, bool) {
 	var fracDiv uint64 = 1
 	if i < len(s) && s[i] == '.' {
 		i++
-		if i == len(s) {
-			return 0, false
-		}
 		for i < len(s) {
 			c := s[i] - '0'
 			if c > 9 {

--- a/parse.go
+++ b/parse.go
@@ -4,6 +4,8 @@ import (
 	"math"
 )
 
+const maxFracDigits = 16
+
 type Signed interface {
 	~int | ~int8 | ~int16 | ~int32 | ~int64
 }
@@ -159,6 +161,7 @@ func parseFloat[S byteSeq](s S) (float64, bool) {
 
 	var fracPart uint64
 	var fracDiv uint64 = 1
+	var fracDigits int
 	if i < len(s) && s[i] == '.' {
 		i++
 		for i < len(s) {
@@ -166,10 +169,12 @@ func parseFloat[S byteSeq](s S) (float64, bool) {
 			if c > 9 {
 				break
 			}
-			if fracDiv < 1e16 {
-				fracPart = fracPart*10 + uint64(c)
-				fracDiv *= 10
+			if fracDigits >= maxFracDigits {
+				return 0, false
 			}
+			fracPart = fracPart*10 + uint64(c)
+			fracDiv *= 10
+			fracDigits++
 			i++
 		}
 	}

--- a/parse_test.go
+++ b/parse_test.go
@@ -403,13 +403,19 @@ func Test_ParseFloat(t *testing.T) {
 		{"-3.14", -3.14, true},
 		{"1e2", 100, true},
 		{"-1.2e3", -1200, true},
+		{"1.", 1, true},
+		{".5", 0.5, true},
+		{"1234567891234567891234567", 1234567891234567891234567, true},
+		{"1.2345678912345678", 1.2345678912345678, true}, // large number
+		{"1.2.3", 0, false},
+		{"1e1.0", 0, false},
 		{"1e309", 0, false},
 		{"", 0, false},
 		{"abc", 0, false},
 	}
 	for _, tt := range tests {
 		v, ok := ParseFloat(tt.in)
-		require.Equal(t, tt.success, ok)
+		require.Equal(t, tt.success, ok, "input: %s", tt.in)
 		if ok {
 			if tt.val == 0 {
 				require.Equal(t, tt.val, v)

--- a/parse_test.go
+++ b/parse_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"math"
 	"strconv"
 	"testing"
 
@@ -391,7 +392,7 @@ func Benchmark_ParseUint8(b *testing.B) {
 	})
 }
 
-func Test_ParseFloat(t *testing.T) {
+func Test_ParseFloat64(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		in      string
@@ -405,43 +406,59 @@ func Test_ParseFloat(t *testing.T) {
 		{"-1.2e3", -1200, true},
 		{"1.", 1, true},
 		{".5", 0.5, true},
-		{"1234567891234567891234567", 1234567891234567891234567, true},
+		{"-0", -0, true},
+		{"+123.45", 123.45, true},
+		{"1e-400", 0, true},
+		{"1234567891234567891234567", 0, false},
 		{"1.2345678912345678", 1.2345678912345678, true}, // large number
 		{"1.2.3", 0, false},
 		{"1e1.0", 0, false},
 		{"1e309", 0, false},
+		{"1e", 0, false},
+		{"1e+", 0, false},
+		{"1e-", 0, false},
 		{"", 0, false},
 		{"abc", 0, false},
+		{"+", 0, false},
+		{"-", 0, false},
+		{"123.", 0, false},
+		{"123e", 0, false},
+		{"123e+", 0, false},
+		{"123e-", 0, false},
+		{"123e1a", 0, false},
+		{"9999999999999999999", 0, false},
+		{".5", 0, false},
+		{"1.2.3", 0, false},
 	}
 	for _, tt := range tests {
-		v, ok := ParseFloat(tt.in)
+		v, ok := ParseFloat64(tt.in)
 		require.Equal(t, tt.success, ok, "input: %s", tt.in)
 		if ok {
 			if tt.val == 0 {
-				require.Equal(t, tt.val, v)
+				require.Equal(t, tt.val, v, "input: %s", tt.in)
 			} else {
-				require.InEpsilon(t, tt.val, v, 1e-9)
+				require.InEpsilon(t, tt.val, v, 1e-9, "input: %s", tt.in)
 			}
 		}
-		bts, ok := ParseFloat([]byte(tt.in))
+		bts, ok := ParseFloat64([]byte(tt.in))
 		require.Equal(t, tt.success, ok)
 		if ok {
 			if tt.val == 0 {
-				require.Equal(t, tt.val, bts)
+				require.Equal(t, tt.val, bts, "input: %s", tt.in)
 			} else {
-				require.InEpsilon(t, tt.val, bts, 1e-9)
+				require.InEpsilon(t, tt.val, bts, 1e-9, "input: %s", tt.in)
 			}
 		}
 	}
 }
 
-func Benchmark_ParseFloat(b *testing.B) {
+func Benchmark_ParseFloat64(b *testing.B) {
 	input := "12345.6789"
 
 	b.Run("fiber", func(b *testing.B) {
 		b.ReportAllocs()
 		for n := 0; n < b.N; n++ {
-			_, ok := ParseFloat(input)
+			_, ok := ParseFloat64(input)
 			if !ok {
 				b.Fatal("failed to parse float")
 			}
@@ -450,7 +467,7 @@ func Benchmark_ParseFloat(b *testing.B) {
 	b.Run("fiber_bytes", func(b *testing.B) {
 		b.ReportAllocs()
 		for n := 0; n < b.N; n++ {
-			_, ok := ParseFloat([]byte(input))
+			_, ok := ParseFloat64([]byte(input))
 			if !ok {
 				b.Fatal("failed to parse float from bytes")
 			}
@@ -460,6 +477,107 @@ func Benchmark_ParseFloat(b *testing.B) {
 		b.ReportAllocs()
 		for n := 0; n < b.N; n++ {
 			_, err := strconv.ParseFloat(input, 64)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func Test_ParseFloat32(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		in      string
+		val     float32
+		success bool
+		negzero bool
+	}{
+		{"0", 0, true, false},
+		{"42.5", 42.5, true, false},
+		{"-3.14", -3.14, true, false},
+		{"1e2", 100, true, false},
+		{"-1.2e3", -1200, true, false},
+		{"1.", 1, true, false},
+		{".5", 0.5, true, false},
+		{"3.4028234e38", 3.4028234e38, true, false},
+		{"-0", -0, true, true},
+		{"1e39", 0, false, false},
+		{"1e", 0, false, false},
+		{"1e+", 0, false, false},
+		{"1e-", 0, false, false},
+		{"1234567891234567891234567", 0, false, false},
+		{"1.2345678912345678", 1.2345679, true, false},
+		{"1.2.3", 0, false, false},
+		{"1e1.0", 0, false, false},
+		{"1e309", 0, false, false},
+		{"+123.45", 123.45, true, false},
+		{"1e-400", 0, true, false},
+		{"", 0, false, false},
+		{"abc", 0, false, false},
+		{"+", 0, false, false},
+		{"-", 0, false, false},
+		{"123.", 0, false, false},
+		{"123e", 0, false, false},
+		{"123e+", 0, false, false},
+		{"123e-", 0, false, false},
+		{"123e1a", 0, false, false},
+		{"9999999999999999999", 0, false, false},
+		{".5", 0, false, false},
+		{"1.2.3", 0, false, false},
+	}
+	for _, tt := range tests {
+		v, ok := ParseFloat32(tt.in)
+		require.Equal(t, tt.success, ok, "input: %s", tt.in)
+		if ok {
+			if tt.negzero {
+				require.Equal(t, float32(0), v)
+				require.True(t, math.Signbit(float64(v)))
+			} else if tt.val == 0 {
+				require.Equal(t, tt.val, v, "input: %s", tt.in)
+			} else {
+				require.InEpsilon(t, tt.val, v, 1e-6, "input: %s", tt.in)
+			}
+		}
+		bts, ok := ParseFloat32([]byte(tt.in))
+		require.Equal(t, tt.success, ok)
+		if ok {
+			if tt.negzero {
+				require.Equal(t, float32(0), bts)
+				require.True(t, math.Signbit(float64(bts)))
+			} else if tt.val == 0 {
+				require.Equal(t, tt.val, bts, "input: %s", tt.in)
+			} else {
+				require.InEpsilon(t, tt.val, bts, 1e-6, "input: %s", tt.in)
+			}
+		}
+	}
+}
+
+func Benchmark_ParseFloat32(b *testing.B) {
+	input := "12345.6789"
+
+	b.Run("fiber", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			_, ok := ParseFloat32(input)
+			if !ok {
+				b.Fatal("failed to parse float32")
+			}
+		}
+	})
+	b.Run("fiber_bytes", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			_, ok := ParseFloat32([]byte(input))
+			if !ok {
+				b.Fatal("failed to parse float32 from bytes")
+			}
+		}
+	})
+	b.Run("default", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			_, err := strconv.ParseFloat(input, 32)
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/parse_test.go
+++ b/parse_test.go
@@ -434,7 +434,7 @@ func Test_ParseFloat64(t *testing.T) {
 		require.Equal(t, tt.success, ok, "input: %s", tt.in)
 		if ok {
 			if tt.val == 0 {
-				require.Equal(t, tt.val, v, "input: %s", tt.in)
+				require.InDelta(t, tt.val, v, 1e-9, "input: %s", tt.in)
 			} else {
 				require.InEpsilon(t, tt.val, v, 1e-9, "input: %s", tt.in)
 			}
@@ -443,7 +443,7 @@ func Test_ParseFloat64(t *testing.T) {
 		require.Equal(t, tt.success, ok)
 		if ok {
 			if tt.val == 0 {
-				require.Equal(t, tt.val, bts, "input: %s", tt.in)
+				require.InDelta(t, tt.val, bts, 1e-9, "input: %s", tt.in)
 			} else {
 				require.InEpsilon(t, tt.val, bts, 1e-9, "input: %s", tt.in)
 			}
@@ -528,10 +528,10 @@ func Test_ParseFloat32(t *testing.T) {
 		require.Equal(t, tt.success, ok, "input: %s", tt.in)
 		if ok {
 			if tt.negzero {
-				require.Equal(t, float32(0), v)
+				require.InDelta(t, float32(0), v, 1e-6, "input: %s", tt.in)
 				require.True(t, math.Signbit(float64(v)))
 			} else if tt.val == 0 {
-				require.Equal(t, tt.val, v, "input: %s", tt.in)
+				require.InDelta(t, tt.val, v, 1e-6, "input: %s", tt.in)
 			} else {
 				require.InEpsilon(t, tt.val, v, 1e-6, "input: %s", tt.in)
 			}
@@ -540,10 +540,10 @@ func Test_ParseFloat32(t *testing.T) {
 		require.Equal(t, tt.success, ok)
 		if ok {
 			if tt.negzero {
-				require.Equal(t, float32(0), bts)
+				require.InDelta(t, float32(0), bts, 1e-6, "input: %s", tt.in)
 				require.True(t, math.Signbit(float64(bts)))
 			} else if tt.val == 0 {
-				require.Equal(t, tt.val, bts, "input: %s", tt.in)
+				require.InDelta(t, tt.val, bts, 1e-6, "input: %s", tt.in)
 			} else {
 				require.InEpsilon(t, tt.val, bts, 1e-6, "input: %s", tt.in)
 			}

--- a/parse_test.go
+++ b/parse_test.go
@@ -421,13 +421,12 @@ func Test_ParseFloat64(t *testing.T) {
 		{"abc", 0, false},
 		{"+", 0, false},
 		{"-", 0, false},
-		{"123.", 0, false},
+		{"123.", 123, true},
 		{"123e", 0, false},
 		{"123e+", 0, false},
 		{"123e-", 0, false},
 		{"123e1a", 0, false},
-		{"9999999999999999999", 0, false},
-		{".5", 0, false},
+		{"9999999999999999999", 1e19, true},
 		{"1.2.3", 0, false},
 	}
 	for _, tt := range tests {
@@ -516,13 +515,12 @@ func Test_ParseFloat32(t *testing.T) {
 		{"abc", 0, false, false},
 		{"+", 0, false, false},
 		{"-", 0, false, false},
-		{"123.", 0, false, false},
+		{"123.", 123, true, false},
 		{"123e", 0, false, false},
 		{"123e+", 0, false, false},
 		{"123e-", 0, false, false},
 		{"123e1a", 0, false, false},
-		{"9999999999999999999", 0, false, false},
-		{".5", 0, false, false},
+		{"9999999999999999999", 1e19, true, false},
 		{"1.2.3", 0, false, false},
 	}
 	for _, tt := range tests {

--- a/parse_test.go
+++ b/parse_test.go
@@ -411,6 +411,7 @@ func Test_ParseFloat64(t *testing.T) {
 		{"1e-400", 0, true},
 		{"1234567891234567891234567", 0, false},
 		{"1.2345678912345678", 1.2345678912345678, true}, // large number
+		{"0.11111111111111119", 0, false},
 		{"1.2.3", 0, false},
 		{"1e1.0", 0, false},
 		{"1e309", 0, false},
@@ -506,6 +507,7 @@ func Test_ParseFloat32(t *testing.T) {
 		{"1e-", 0, false, false},
 		{"1234567891234567891234567", 0, false, false},
 		{"1.2345678912345678", 1.2345679, true, false},
+		{"0.11111111111111119", 0, false, false},
 		{"1.2.3", 0, false, false},
 		{"1e1.0", 0, false, false},
 		{"1e309", 0, false, false},


### PR DESCRIPTION
```
Benchmark_ParseFloat64/fiber-12               130381844        9.355 ns/op       0 B/op       0 allocs/op
Benchmark_ParseFloat64/fiber-12               129132879        9.170 ns/op       0 B/op       0 allocs/op
Benchmark_ParseFloat64/fiber_bytes-12         125142489        9.786 ns/op       0 B/op       0 allocs/op
Benchmark_ParseFloat64/fiber_bytes-12         125434107        9.617 ns/op       0 B/op       0 allocs/op
Benchmark_ParseFloat64/default-12              49301054        24.17 ns/op       0 B/op       0 allocs/op
Benchmark_ParseFloat64/default-12              48115717        24.16 ns/op       0 B/op       0 allocs/op

Benchmark_ParseFloat32/fiber-12               100000000        10.11 ns/op       0 B/op       0 allocs/op
Benchmark_ParseFloat32/fiber-12               100000000        10.14 ns/op       0 B/op       0 allocs/op
Benchmark_ParseFloat32/fiber_bytes-12         100000000        10.44 ns/op       0 B/op       0 allocs/op
Benchmark_ParseFloat32/fiber_bytes-12         100000000        10.61 ns/op       0 B/op       0 allocs/op
Benchmark_ParseFloat32/default-12              46581891        25.97 ns/op       0 B/op       0 allocs/op
Benchmark_ParseFloat32/default-12              44455900        26.94 ns/op       0 B/op       0 allocs/op
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new function for parsing floating-point numbers from strings and byte slices.
  * Added comprehensive tests and benchmarks for the new float parsing functionality.

* **Documentation**
  * Updated the README with improved formatting and added new benchmark results for float parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->