### PR TITLE
Expand test coverage

### DIFF
--- a/bytes_test.go
+++ b/bytes_test.go
@@ -73,3 +73,33 @@ func Benchmark_ToUpperBytes(b *testing.B) {
 		require.Equal(b, want, res)
 	})
 }
+
+func Test_ToLowerBytes_Edge(t *testing.T) {
+	t.Parallel()
+
+	cases := [][]byte{
+		{},
+		[]byte("123"),
+		[]byte("!@#"),
+	}
+	for _, c := range cases {
+		t.Run(string(c), func(t *testing.T) {
+			require.Equal(t, bytes.ToLower(c), ToLowerBytes(c))
+		})
+	}
+}
+
+func Test_ToUpperBytes_Edge(t *testing.T) {
+	t.Parallel()
+
+	cases := [][]byte{
+		{},
+		[]byte("123"),
+		[]byte("!@#"),
+	}
+	for _, c := range cases {
+		t.Run(string(c), func(t *testing.T) {
+			require.Equal(t, bytes.ToUpper(c), ToUpperBytes(c))
+		})
+	}
+}

--- a/byteseq_test.go
+++ b/byteseq_test.go
@@ -282,3 +282,23 @@ func Benchmark_TrimBytes(b *testing.B) {
 		require.Equal(b, expected, res)
 	})
 }
+
+func Test_Trim_Edge(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		input string
+		cut   byte
+		exp   string
+	}{
+		{"foobar", 'x', "foobar"},
+		{"", ' ', ""},
+		{"xxfoobarxx", 'x', "foobar"},
+	}
+	for _, c := range cases {
+		t.Run(c.input, func(t *testing.T) {
+			require.Equal(t, c.exp, Trim(c.input, c.cut))
+			require.Equal(t, []byte(c.exp), Trim([]byte(c.input), c.cut))
+		})
+	}
+}

--- a/cbor_test.go
+++ b/cbor_test.go
@@ -108,3 +108,12 @@ func Test_DefaultCBORDecoderWithUnitializedStruct(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, emptySs, ss)
 }
+
+func Test_CBORDecodeInvalid(t *testing.T) {
+	t.Parallel()
+
+	data := []byte{0xff, 0xff}
+	var ss sampleStructure
+	err := cbor.Unmarshal(data, &ss)
+	require.Error(t, err)
+}

--- a/common_test.go
+++ b/common_test.go
@@ -209,6 +209,16 @@ func Test_GetArgument(t *testing.T) {
 	require.False(t, GetArgument("missing-arg"))
 }
 
+func Test_GetArgument_Multiple(t *testing.T) {
+	original := os.Args
+	defer func() { os.Args = original }()
+
+	os.Args = []string{"cmd", "-a", "-b", "--flag"}
+	require.True(t, GetArgument("-a"))
+	require.True(t, GetArgument("--flag"))
+	require.False(t, GetArgument("-c"))
+}
+
 func Test_IncrementIPRange(t *testing.T) {
 	t.Parallel()
 

--- a/convert_test.go
+++ b/convert_test.go
@@ -159,6 +159,11 @@ func Test_ToString(t *testing.T) {
 			require.Equal(t, tc.expected, res)
 		})
 	}
+
+	t.Run("nil", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, "<nil>", ToString(nil))
+	})
 }
 
 func TestCopyBytes(t *testing.T) {

--- a/file_test.go
+++ b/file_test.go
@@ -206,3 +206,11 @@ func Test_ReadFile_NoFS(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, string(data), "doe")
 }
+
+func Test_ReadFile_SubDir(t *testing.T) {
+	t.Parallel()
+
+	data, err := ReadFile("example/example1.txt", http.FS(os.DirFS(".github/tests")))
+	require.NoError(t, err)
+	require.NotNil(t, data)
+}

--- a/http_test.go
+++ b/http_test.go
@@ -42,6 +42,9 @@ func Test_GetMIME(t *testing.T) {
 		require.Equal(t, "application/javascript", res)
 	}
 	require.NoError(t, err)
+
+	require.Equal(t, "application/json", GetMIME(".JSON"))
+	require.Equal(t, MIMEOctetStream, GetMIME("  .json"))
 }
 
 // go test -v -run=^$ -bench=Benchmark_GetMIME -benchmem -count=2
@@ -208,6 +211,12 @@ func Test_StatusMessage(t *testing.T) {
 
 	res = StatusMessage(600)
 	require.Equal(t, "", res)
+
+	res = StatusMessage(100)
+	require.Equal(t, "Continue", res)
+
+	res = StatusMessage(http.StatusTeapot)
+	require.Equal(t, "I'm a teapot", res)
 }
 
 // go test -run=^$ -bench=Benchmark_StatusMessage -benchmem -count=2

--- a/ips_test.go
+++ b/ips_test.go
@@ -92,6 +92,15 @@ func Test_IsIPv6_EdgeCases(t *testing.T) {
 	require.False(t, IsIPv6("1::2:3:4:5:6:7:8"))
 }
 
+func Test_IPWhitespace(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, IsIPv4(" 1.1.1.1"))
+	require.False(t, IsIPv4("1.1.1.1 "))
+	require.False(t, IsIPv6(" ::1"))
+	require.False(t, IsIPv6("::1 "))
+}
+
 // go test -v -run=^$ -bench=UnsafeString -benchmem -count=2
 func Benchmark_IsIPv4(b *testing.B) {
 	ip := "174.23.33.100"

--- a/json_test.go
+++ b/json_test.go
@@ -58,3 +58,11 @@ func Test_DefaultJSONDecoder(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "Hello World", ss.ImportantString)
 }
+
+func Test_JSONDecodeInvalid(t *testing.T) {
+	t.Parallel()
+
+	var ss sampleStructure
+	err := json.Unmarshal([]byte("{invalid}"), &ss)
+	require.Error(t, err)
+}

--- a/msgpack_test.go
+++ b/msgpack_test.go
@@ -49,3 +49,11 @@ func Test_MsgpackDecoder(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "Hello World", decoded.ImportantString)
 }
+
+func Test_MsgpackDecodeInvalid(t *testing.T) {
+	t.Parallel()
+
+	var decoded sampleMsgPackStructure
+	err := msgpack.Unmarshal([]byte{0xff, 0xff}, &decoded)
+	require.Error(t, err)
+}

--- a/parse_test.go
+++ b/parse_test.go
@@ -35,6 +35,14 @@ func Test_ParseUint(t *testing.T) {
 	}
 }
 
+func Test_ParseUint_Whitespace(t *testing.T) {
+	t.Parallel()
+
+	v, ok := ParseUint(" 123")
+	require.False(t, ok)
+	require.Equal(t, uint64(0), v)
+}
+
 func Benchmark_ParseUint(b *testing.B) {
 	input := "123456789"
 
@@ -108,6 +116,14 @@ func Test_ParseInt_SignOnly(t *testing.T) {
 		require.False(t, ok)
 		require.Equal(t, int64(0), b)
 	}
+}
+
+func Test_ParseInt_Whitespace(t *testing.T) {
+	t.Parallel()
+
+	v, ok := ParseInt(" 42")
+	require.False(t, ok)
+	require.Equal(t, int64(0), v)
 }
 
 func Test_ParseUnsigned_SignOnly(t *testing.T) {

--- a/strings_test.go
+++ b/strings_test.go
@@ -213,6 +213,13 @@ func Test_NonASCII_Unchanged(t *testing.T) {
 		require.Equal(t, nonASCII, ToUpper(nonASCII), "ToUpper altered non-ASCII")
 		require.Equal(t, nonASCII, ToLower(nonASCII), "ToLower altered non-ASCII")
 	})
+
+	mixed := "Goµ"
+	t.Run("mixed", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, "GOµ", ToUpper(mixed))
+		require.Equal(t, "goµ", ToLower(mixed))
+	})
 }
 
 func Benchmark_ToUpper(b *testing.B) {

--- a/time_test.go
+++ b/time_test.go
@@ -112,3 +112,17 @@ func Benchmark_CalculateTimestamp(b *testing.B) {
 		}
 	})
 }
+
+func Test_StartStopRepeat(t *testing.T) {
+	timerTestMu.Lock()
+	defer timerTestMu.Unlock()
+
+	StartTimeStampUpdater()
+	StopTimeStampUpdater()
+	StartTimeStampUpdater()
+	defer StopTimeStampUpdater()
+
+	time.Sleep(50 * time.Millisecond)
+	ts := Timestamp()
+	require.NotZero(t, ts)
+}

--- a/xml_test.go
+++ b/xml_test.go
@@ -136,3 +136,11 @@ func Benchmark_DefaultXMLDecoder(b *testing.B) {
 		}
 	}
 }
+
+func Test_XMLDecodeInvalid(t *testing.T) {
+	t.Parallel()
+
+	var ss serversXMLStructure
+	err := xml.Unmarshal([]byte("<invalid>"), &ss)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary
- add edge case checks for byte conversions
- extend trim and CBOR tests
- test argument parsing, ToString nil, and subdirectory reads
- verify MIME lookup, IPv validation, JSON/XML/Msgpack decode errors, and more
- exercise whitespace parsing and mixed ASCII/non-ASCII cases
- add start/stop cycle test for timestamp updater

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6873eabd4cf4833394bef04e88d2de58