### PR TITLE
Revert "Add UUID alias for UUIDv4"

### DIFF
--- a/common.go
+++ b/common.go
@@ -48,12 +48,6 @@ func UUIDv4() string {
 	return token.String()
 }
 
-// UUID generates an universally unique identifier (UUID).
-// This is an alias for UUIDv4 for backward compatibility.
-func UUID() string {
-	return UUIDv4()
-}
-
 // GenerateSecureToken generates a cryptographically secure random token encoded in base64.
 // It uses crypto/rand for randomness and base64.RawURLEncoding for URL-safe output.
 // If length is less than or equal to 0, it defaults to 32 bytes (256 bits of entropy).


### PR DESCRIPTION
Reverts gofiber/utils#178

The function was intentionally removed in v2 in #175 as a documented breaking change. Reintroducing it is unnecessary, as v2 has not yet had a final release and such changes are acceptable in a major version release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the `UUID()` function. Use `UUIDv4()` directly instead.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->