### PR TITLE
📒 docs: improve deprecated comments

### DIFF
--- a/bytes.go
+++ b/bytes.go
@@ -10,16 +10,20 @@ import (
 
 // ToLowerBytes converts an ASCII byte slice to lower-case in-place.
 //
-// Deprecated: use package "github.com/gofiber/utils/v2/bytes" and call bytes.UnsafeToLower.
+// Deprecated: use [github.com/gofiber/utils/v2/bytes.UnsafeToLower] instead.
 // This wrapper keeps backward compatibility by mutating the provided slice.
+//
+//go:fix inline
 func ToLowerBytes(b []byte) []byte {
 	return casebytes.UnsafeToLower(b)
 }
 
 // ToUpperBytes converts an ASCII byte slice to upper-case in-place.
 //
-// Deprecated: use package "github.com/gofiber/utils/v2/bytes" and call bytes.UnsafeToUpper.
+// Deprecated: use [github.com/gofiber/utils/v2/bytes.UnsafeToUpper] instead.
 // This wrapper keeps backward compatibility by mutating the provided slice.
+//
+//go:fix inline
 func ToUpperBytes(b []byte) []byte {
 	return casebytes.UnsafeToUpper(b)
 }

--- a/strings.go
+++ b/strings.go
@@ -10,14 +10,18 @@ import (
 
 // ToLower converts ascii string to lower-case.
 //
-// Deprecated: use package "github.com/gofiber/utils/v2/strings" and call strings.ToLower.
+// Deprecated: use [github.com/gofiber/utils/v2/strings.ToLower] instead.
+//
+//go:fix inline
 func ToLower(b string) string {
 	return casestrings.ToLower(b)
 }
 
 // ToUpper converts ascii string to upper-case.
 //
-// Deprecated: use package "github.com/gofiber/utils/v2/strings" and call strings.ToUpper.
+// Deprecated: use [github.com/gofiber/utils/v2/strings.ToUpper] instead.
+//
+//go:fix inline
 func ToUpper(b string) string {
 	return casestrings.ToUpper(b)
 }


### PR DESCRIPTION
This PR improves deprecated functions:

- Now godoc links are clickable.
- Now we can use `go fix -inline` to automatically migrate, see https://go.dev/blog/inliner.

Before:

<img width="1146" height="464" alt="image" src="https://github.com/user-attachments/assets/d801454d-0d1f-4228-a75c-c038561fe442" />

After:

<img width="1142" height="461" alt="image" src="https://github.com/user-attachments/assets/18dbcf86-c48e-4faa-afb2-cb9a9c10a4db" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated deprecation notices for `ToLowerBytes`, `ToUpperBytes`, `ToLower`, and `ToUpper` functions with direct references to their replacements in the new utility package location. Users should migrate to the updated function paths for continued support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->