### PR TITLE
🐛 fix: prevent content-type confusion in ParseVendorSpecificContentType

### DIFF
--- a/http.go
+++ b/http.go
@@ -11,10 +11,10 @@ import (
 
 const MIMEOctetStream = "application/octet-stream"
 const (
-	contentTypeApplicationJSON               = "application/json"
-	contentTypeApplicationXML                = "application/xml"
-	contentTypeApplicationFormURLEncoded     = "application/x-www-form-urlencoded"
-	contentTypePrefixApplicationWithSlash    = "application/"
+	contentTypeApplicationJSON            = "application/json"
+	contentTypeApplicationXML             = "application/xml"
+	contentTypeApplicationFormURLEncoded  = "application/x-www-form-urlencoded"
+	contentTypePrefixApplicationWithSlash = "application/"
 )
 
 // GetMIME returns the content-type of a file extension

--- a/http.go
+++ b/http.go
@@ -14,7 +14,7 @@ const (
 	contentTypeApplicationJSON               = "application/json"
 	contentTypeApplicationXML                = "application/xml"
 	contentTypeApplicationFormURLEncoded     = "application/x-www-form-urlencoded"
-	contentTypePrefixApplicationWithSlashLen = len("application/")
+	contentTypePrefixApplicationWithSlash    = "application/"
 )
 
 // GetMIME returns the content-type of a file extension
@@ -80,7 +80,7 @@ func ParseVendorSpecificContentType(cType string, caseInsensitive ...bool) strin
 		return cType
 	}
 
-	if slashIndex+1 == contentTypePrefixApplicationWithSlashLen {
+	if strings.HasPrefix(working, contentTypePrefixApplicationWithSlash) {
 		switch parsableType {
 		case "json":
 			return contentTypeApplicationJSON

--- a/http_test.go
+++ b/http_test.go
@@ -102,6 +102,9 @@ func Test_ParseVendorSpecificContentType(t *testing.T) {
 	cType = ParseVendorSpecificContentType("text/vnd.example+plain")
 	require.Equal(t, "text/plain", cType)
 
+	cType = ParseVendorSpecificContentType("aaaaaaaaaaa/vnd.api+json")
+	require.Equal(t, "aaaaaaaaaaa/json", cType)
+
 	cType = ParseVendorSpecificContentType("application/vnd.test+json;boundary=test")
 	require.Equal(t, "application/json", cType)
 


### PR DESCRIPTION
### Motivation
- Prevent misclassification of non-application media types caused by a length/position-based fast-path in `ParseVendorSpecificContentType` that could treat any top-level token with the same slash position as `application/` as `application/*`.

### Description
- Replace the length/position check with an explicit prefix check using `strings.HasPrefix(working, "application/")`, change the constant to `contentTypePrefixApplicationWithSlash`, and add a regression test for the input `aaaaaaaaaaa/vnd.api+json` to ensure the original top-level type is preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved content-type detection logic for more reliable handling of application-style types.

* **Tests**
  * Added coverage for vendor-specific content types, including extended-prefix edge cases to ensure correct normalization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gofiber/utils/pull/198)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->