### PR TITLE
🐛 fix: restore strict overflow check in float parser

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -5,7 +5,11 @@ import (
 	"strconv"
 )
 
-const maxFracDigits = 16
+const (
+	maxFracDigits   = 16
+	maxUint64Cutoff = math.MaxUint64 / 10
+	maxUint64Cutlim = math.MaxUint64 % 10
+)
 
 type Signed interface {
 	~int | ~int8 | ~int16 | ~int32 | ~int64
@@ -136,10 +140,6 @@ func ParseUint8[S byteSeq](s S) (uint8, error) {
 // It returns an error if any non-digit is encountered or overflow happens.
 func parseDigits[S byteSeq](s S, i int) (uint64, error) {
 	var n uint64
-	const (
-		cutoff = math.MaxUint64 / 10
-		cutlim = math.MaxUint64 % 10
-	)
 	digits := 0
 	for ; i < len(s); i++ {
 		c := s[i] - '0'
@@ -148,7 +148,7 @@ func parseDigits[S byteSeq](s S, i int) (uint64, error) {
 		}
 		d := uint64(c)
 		// Any value with <= 19 digits is guaranteed to fit in uint64.
-		if digits >= 19 && (n > cutoff || (n == cutoff && d > cutlim)) {
+		if digits >= 19 && (n > maxUint64Cutoff || (n == maxUint64Cutoff && d > maxUint64Cutlim)) {
 			return 0, strconv.ErrRange
 		}
 		n = n*10 + d
@@ -240,14 +240,12 @@ func parseFloat[S byteSeq](fn string, s S) (float64, error) {
 	}
 
 	var intPart uint64
-	const maxUint64Div10 = ^uint64(0) / 10
-	const maxUint64Mod10 = ^uint64(0) % 10
 	for i < len(s) {
 		c := s[i] - '0'
 		if c > 9 {
 			break
 		}
-		if intPart > maxUint64Div10 || (intPart == maxUint64Div10 && uint64(c) > maxUint64Mod10) {
+		if intPart > maxUint64Cutoff || (intPart == maxUint64Cutoff && uint64(c) > maxUint64Cutlim) {
 			return 0, &strconv.NumError{Func: fn, Num: string(s), Err: strconv.ErrRange}
 		}
 		intPart = intPart*10 + uint64(c)

--- a/parse.go
+++ b/parse.go
@@ -240,16 +240,17 @@ func parseFloat[S byteSeq](fn string, s S) (float64, error) {
 	}
 
 	var intPart uint64
+	const maxUint64Div10 = ^uint64(0) / 10
+	const maxUint64Mod10 = ^uint64(0) % 10
 	for i < len(s) {
 		c := s[i] - '0'
 		if c > 9 {
 			break
 		}
-		nn := intPart*10 + uint64(c)
-		if nn < intPart {
+		if intPart > maxUint64Div10 || (intPart == maxUint64Div10 && uint64(c) > maxUint64Mod10) {
 			return 0, &strconv.NumError{Func: fn, Num: string(s), Err: strconv.ErrRange}
 		}
-		intPart = nn
+		intPart = intPart*10 + uint64(c)
 		i++
 	}
 

--- a/parse_test.go
+++ b/parse_test.go
@@ -556,6 +556,7 @@ func Test_ParseFloat64(t *testing.T) {
 		{strconv.FormatFloat(-math.MaxFloat64, 'g', -1, 64), -math.MaxFloat64, true},
 		{"5e-324", 0, true},
 		{"1e-400", 0, true},
+		{"25000000000000000000e-18", 0, false},
 		{"1234567891234567891234567", 0, false},
 		{"1.2345678912345678", 1.2345678912345678, true}, // large number
 		{"0.11111111111111119", 0, false},


### PR DESCRIPTION
### Motivation
- Repair a regression in `parseFloat` where the integer mantissa accumulation allowed uint64 wraparound and produced incorrect parsed float values for oversized decimal mantissas. 
- Prevent attacker-controlled inputs from being misparsed (e.g. `25000000000000000000e-18`) which could bypass numeric validation.

### Description
- Restore a pre-multiply overflow check in `parseFloat` by adding `maxUint64Div10` and `maxUint64Mod10` and validating `intPart` before computing `intPart*10 + digit` in `parse.go`.
- Replace the post-multiply monotonicity test with the precise boundary check and then perform the multiplication/accumulation only after it passes.
- Add a regression test case for the problematic input `"25000000000000000000e-18"` in `parse_test.go` and mark it as an expected parse error to ensure the overflow is rejected going forward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved overflow checks during numeric parsing so extremely large integers/floats are detected earlier and reported as out-of-range instead of producing incorrect results.

* **Tests**
  * Added coverage for an edge-case large numeric literal to ensure parsing fails appropriately at numeric boundaries.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gofiber/utils/pull/199)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->