### PR TITLE
test(format): measure realistic allocations in Format/Append benchmarks

### DIFF
--- a/format_test.go
+++ b/format_test.go
@@ -152,14 +152,14 @@ func Benchmark_FormatUint(b *testing.B) {
 	for _, input := range inputs {
 		b.Run(input.name+"/fiber", func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
-				_ = FormatUint(input.value)
+			for b.Loop() {
+				FormatUint(input.value)
 			}
 		})
 		b.Run(input.name+"/strconv", func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
-				_ = strconv.FormatUint(input.value, 10)
+			for b.Loop() {
+				strconv.FormatUint(input.value, 10)
 			}
 		})
 	}
@@ -181,14 +181,14 @@ func Benchmark_FormatInt(b *testing.B) {
 	for _, input := range inputs {
 		b.Run(input.name+"/fiber", func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
-				_ = FormatInt(input.value)
+			for b.Loop() {
+				FormatInt(input.value)
 			}
 		})
 		b.Run(input.name+"/strconv", func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
-				_ = strconv.FormatInt(input.value, 10)
+			for b.Loop() {
+				strconv.FormatInt(input.value, 10)
 			}
 		})
 	}
@@ -199,14 +199,14 @@ func Benchmark_FormatUint32(b *testing.B) {
 
 	b.Run("fiber", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
-			_ = FormatUint32(input)
+		for b.Loop() {
+			FormatUint32(input)
 		}
 	})
 	b.Run("strconv", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
-			_ = strconv.FormatUint(uint64(input), 10)
+		for b.Loop() {
+			strconv.FormatUint(uint64(input), 10)
 		}
 	})
 }
@@ -216,14 +216,14 @@ func Benchmark_FormatInt32(b *testing.B) {
 
 	b.Run("fiber", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
-			_ = FormatInt32(input)
+		for b.Loop() {
+			FormatInt32(input)
 		}
 	})
 	b.Run("strconv", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
-			_ = strconv.FormatInt(int64(input), 10)
+		for b.Loop() {
+			strconv.FormatInt(int64(input), 10)
 		}
 	})
 }
@@ -233,14 +233,14 @@ func Benchmark_FormatUint16(b *testing.B) {
 
 	b.Run("fiber", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
-			_ = FormatUint16(input)
+		for b.Loop() {
+			FormatUint16(input)
 		}
 	})
 	b.Run("strconv", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
-			_ = strconv.FormatUint(uint64(input), 10)
+		for b.Loop() {
+			strconv.FormatUint(uint64(input), 10)
 		}
 	})
 }
@@ -250,14 +250,14 @@ func Benchmark_FormatInt16(b *testing.B) {
 
 	b.Run("fiber", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
-			_ = FormatInt16(input)
+		for b.Loop() {
+			FormatInt16(input)
 		}
 	})
 	b.Run("strconv", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
-			_ = strconv.FormatInt(int64(input), 10)
+		for b.Loop() {
+			strconv.FormatInt(int64(input), 10)
 		}
 	})
 }
@@ -267,14 +267,14 @@ func Benchmark_FormatUint8(b *testing.B) {
 
 	b.Run("fiber", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
-			_ = FormatUint8(input)
+		for b.Loop() {
+			FormatUint8(input)
 		}
 	})
 	b.Run("strconv", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
-			_ = strconv.FormatUint(uint64(input), 10)
+		for b.Loop() {
+			strconv.FormatUint(uint64(input), 10)
 		}
 	})
 }
@@ -284,14 +284,14 @@ func Benchmark_FormatInt8(b *testing.B) {
 
 	b.Run("fiber", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
-			_ = FormatInt8(input)
+		for b.Loop() {
+			FormatInt8(input)
 		}
 	})
 	b.Run("strconv", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
-			_ = strconv.FormatInt(int64(input), 10)
+		for b.Loop() {
+			strconv.FormatInt(int64(input), 10)
 		}
 	})
 }
@@ -302,14 +302,14 @@ func Benchmark_AppendUint(b *testing.B) {
 
 	b.Run("fiber", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
-			_ = AppendUint(dst, input)
+		for b.Loop() {
+			AppendUint(dst, input)
 		}
 	})
 	b.Run("strconv", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
-			_ = strconv.AppendUint(dst, input, 10)
+		for b.Loop() {
+			strconv.AppendUint(dst, input, 10)
 		}
 	})
 }
@@ -327,14 +327,14 @@ func Benchmark_AppendInt(b *testing.B) {
 	for _, input := range inputs {
 		b.Run(input.name+"/fiber", func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
-				_ = AppendInt(dst, input.value)
+			for b.Loop() {
+				AppendInt(dst, input.value)
 			}
 		})
 		b.Run(input.name+"/strconv", func(b *testing.B) {
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
-				_ = strconv.AppendInt(dst, input.value, 10)
+			for b.Loop() {
+				strconv.AppendInt(dst, input.value, 10)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

The `Format*` / `Append*` benchmarks discarded their result with `_ =`. For
inlinable functions such as `FormatUint`, escape analysis then kept the returned
string on the stack, reporting a misleading `0 allocs/op` that real callers,
which retain the returned string, never observe.

This switches the benchmark loops to `b.Loop()` (Go 1.24+). `b.Loop()` keeps call
results alive, so the value escapes and the benchmark measures the true allocation
cost - giving a fair `fiber` vs `strconv` comparison. As a bonus it resolves the
`modernize` linter's `bloop` suggestion for these loops.

## Measured impact (methodology fix, not a perf change)

`FormatUint/medium`:

| | B/op | allocs/op |
|---|---|---|
| before (`_ =` discard) | 0 | 0 (misleading) |
| after (`b.Loop()`) | 16 | 1 (the real cost) |

Genuine `fiber` wins stay visible and honest: the small-value cache (e.g.
`FormatInt/small_neg`: 0 allocs vs strconv's 1) and `FormatUint32` (CPU). The
apparent advantage for small positive values was itself a measurement artifact
and correctly disappears under `b.Loop()`.

## Notes

- No production code changed - only `format_test.go`.
- `gofumpt`, `go vet` and `golangci-lint` v2.6.1 are clean for the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
