### PR TITLE
⚡ perf(simd): unroll the AVX2 kernels, accelerate the ASCII scans, and drop the SWAR bounds checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,11 +631,15 @@ prefilters on the needle's rarest bytes (`SelectRareBytes`, `ByteRank`)
 before verifying candidates — 2-6 byte needles containing two distinct
 values are scanned for their two rarest bytes at the exact relative
 distance, longer or single-valued needles for the single rarest byte.
-Each kernel classifies four 32-byte vectors per iteration and combines
-their masks, so a 128-byte block costs a single `VPMOVMSKB` and a single
-branch; the first-match scans then re-extract the four masks in address
-order on the (rare) hit path to locate the match. One tier is documented
-explicitly as unaccelerated: `MemchrInTable`/`MemchrNotInTable` are plain
+Each kernel classifies four 32-byte vectors per iteration. Where the
+result is a position or a yes/no, the four masks are combined, so a
+128-byte block costs a single `VPMOVMSKB` and a single branch, and the
+scans that report a position re-extract the four masks in address order on
+the (rare) hit path. `CountNonASCII` is the exception — a count cannot be
+recovered from a combined mask, so it extracts and population-counts all
+four, and it is the one kernel gated on `POPCNT` in addition to AVX2.
+One tier is documented explicitly as unaccelerated:
+`MemchrInTable`/`MemchrNotInTable` are plain
 scalar loops, since an arbitrary 256-entry membership test has no cheap
 vector form. There is deliberately no single-needle `Memchr`:
 `bytes.IndexByte` is already vector-accelerated by the Go runtime. `Memmem`
@@ -671,12 +675,38 @@ below reports -26.6%/-49.7% ns/op for `Memchr2` at 512B/4096B,
 -17.6%/-34.3% for `Memchr3`, -13.4%/-24.6% for `MemchrPair`,
 -39.2%/-50.5% for `MemchrDigit`, -53.5%/-63.7% for `MemchrNotWord`,
 -42.2%/-65.7% for `IsASCII`, and -13.7%/-27.1% for `Memmem`, which rides
-the paired scan; sub-vector inputs are unchanged, since they never reach
-the kernels. The two portable-fallback changes that survived measurement
-are the ASCII scan (-25% at 8B, -32% at 4096B) and the digit scan (-12%
-to -17% from 32B up); unrolling the multi-needle, `\w` and counting
-fallbacks measured neutral to worse in a same-process A/B, so those keep
-their single-word loops.
+the paired scan. Those percentages come from `benchstat` over ten runs of
+each side; the single-run table below is a catalog, not a base-vs-head
+comparison, so subtracting its rows from an older copy of it will not
+reproduce them.
+
+Two bands see no benefit and are worth stating plainly. Inputs below
+`simd.MinLen` never reach the kernels at all. Inputs of 32-127 bytes do
+reach them but skip the 128-byte block loop, so they pay its setup with
+nothing to amortize it against: across that band `benchstat` reports the
+class scans clearly ahead (`MemchrNotWord` -8.6% at 32B, -18.4% at 64B;
+`IsASCII` -5.0%/-4.3%), most rows statistically unchanged, and two small
+regressions — `MemchrDigit` +5.6% at 32B and `Memchr3` +3.8% at 64B.
+
+On the portable side, pinning each unrolled group of words with a reslice
+before loading at constant offsets inside it removes the per-load bounds
+check that `swar.Load8`'s own reslice otherwise repeats. Measured with
+`benchstat -count=10` against the same fallbacks, at 32B/512B/4KiB:
+`IsASCII` -28%/-60%/-63%, `CountNonASCII` -24%/-44%/-44%,
+`FirstNonASCII` -23%/-37%/-43%, `Memchr2` -19%/-23%/-25%,
+`MemchrDigit` -7%/-12%/-17%, `Memchr3` -8%/-13%/-18%,
+`MemchrWord` -11%/-8%/-11%, `MemchrNotWord` -5%/-7%/-6%. The tier a group
+adds costs one compare on inputs too short to use it, which shows up as
++3% to +10% on some of the 8B fallback rows — a few tenths of a
+nanosecond, and only below the length where the group pays for itself.
+`utils.IsASCII` carries the same rework, so the two copies of that scan
+stay in step.
+
+Making the counting kernel finish its own sub-vector remainder (rather
+than splitting the input in Go and calling the SWAR loop for the tail)
+also removed a second non-inlinable call from every whole-vector input:
+`CountNonASCII` at 32B went from 11.3ns — behind its own fallback — to
+6.8ns, level with it, and it leads from 64B up.
 
 Because the AVX2 kernels only engage on amd64, their benchmark numbers are
 recorded separately from the arm64 catalog above:
@@ -689,154 +719,154 @@ cpu: Intel(R) Xeon(R) Processor @ 2.80GHz (AVX2)
 
 ```text
 // go test ./simd/ -benchmem -run=^$ -bench=Benchmark_ -count=1
-Benchmark_Memchr2/8B/simd-4                                        165315782    7.315  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr2/8B/swar-4                                        196491015    6.137  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr2/8B/default-4                                      28966648    40.60  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr2/32B/simd-4                                       187528609    6.549  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr2/32B/swar-4                                        89646259    13.05  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr2/32B/default-4                                     28096137    45.91  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr2/64B/simd-4                                       158776046    7.623  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr2/64B/swar-4                                        57170502    21.78  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr2/64B/default-4                                     20759750    61.65  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr2/512B/simd-4                                       77927769    16.00  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr2/512B/swar-4                                        7770205    156.9  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr2/512B/default-4                                     3071950    402.4  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr2/4096B/simd-4                                      17414829    72.99  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr2/4096B/swar-4                                       1000000     1244  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr2/4096B/default-4                                     379147     3146  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr3/8B/simd-4                                        147468846    8.341  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr3/8B/swar-4                                        176507472    6.800  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr3/8B/default-4                                      28842992    40.00  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr3/32B/simd-4                                       160795072    7.650  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr3/32B/swar-4                                        78000026    15.53  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr3/32B/default-4                                     26226373    44.36  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr3/64B/simd-4                                       142414808    8.458  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr3/64B/swar-4                                        43815084    27.48  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr3/64B/default-4                                     18827344    71.12  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr3/512B/simd-4                                       60840774    19.69  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr3/512B/swar-4                                        5980300    188.4  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr3/512B/default-4                                     3097173    435.4  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr3/4096B/simd-4                                      11583232    97.17  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr3/4096B/swar-4                                        819153     1531  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr3/4096B/default-4                                     390268     2998  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrPair/8B/simd-4                                      91713038    12.58  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrPair/8B/scalar-4                                   204832017    6.559  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrPair/32B/simd-4                                     58506270    21.13  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrPair/32B/scalar-4                                   57385882    21.93  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrPair/64B/simd-4                                    127400613    9.210  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrPair/64B/scalar-4                                   29796430    41.77  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrPair/512B/simd-4                                    62287556    18.71  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrPair/512B/scalar-4                                   2986849    349.1  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrPair/4096B/simd-4                                   12880382    94.26  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrPair/4096B/scalar-4                                   451850     2679  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrDigit/8B/simd-4                                    183451314    6.513  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrDigit/8B/scalar-4                                  212146264    5.553  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrDigit/32B/simd-4                                   187313154    6.495  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrDigit/32B/scalar-4                                 100000000    10.90  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrDigit/64B/simd-4                                   160148972    7.463  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrDigit/64B/scalar-4                                  56653626    22.08  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrDigit/512B/simd-4                                   76820638    15.60  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrDigit/512B/scalar-4                                  8258727    149.2  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrDigit/4096B/simd-4                                  13186258    87.90  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrDigit/4096B/scalar-4                                 1000000     1199  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrWord/8B/simd-4                                     100000000    11.21  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrWord/8B/scalar-4                                   128865920    8.660  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrWord/32B/simd-4                                    169381110    6.996  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrWord/32B/scalar-4                                   37175652    33.52  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrWord/64B/simd-4                                    141170670    8.620  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrWord/64B/scalar-4                                   22469738    48.16  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrWord/512B/simd-4                                    59720695    20.28  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrWord/512B/scalar-4                                   3151227    390.4  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrWord/4096B/simd-4                                   10121071    117.0  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrWord/4096B/scalar-4                                   403077     3049  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrNotWord/8B/simd-4                                  118039993    9.757  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrNotWord/8B/scalar-4                                150062998    8.823  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrNotWord/32B/simd-4                                 149304132    7.276  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrNotWord/32B/scalar-4                                45402106    26.49  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrNotWord/64B/simd-4                                 128084203    8.693  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrNotWord/64B/scalar-4                                23453022    52.32  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrNotWord/512B/simd-4                                 55942212    19.85  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrNotWord/512B/scalar-4                                3025902    417.7  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrNotWord/4096B/simd-4                                10867442    112.6  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrNotWord/4096B/scalar-4                                343974     3397  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem/8B/simd-4                                         100000000    11.52  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem/8B/default-4                                      133979869    8.818  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem/32B/simd-4                                         77301547    15.97  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem/32B/default-4                                      94086402    12.82  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem/64B/simd-4                                         60822933    19.05  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem/64B/default-4                                      71626387    16.13  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem/96B/simd-4                                         23305447    52.33  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem/96B/default-4                                      22869541    52.19  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem/128B/simd-4                                        50354059    24.64  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem/128B/default-4                                     19627141    66.74  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem/192B/simd-4                                        43966809    26.97  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem/192B/default-4                                     12731815    92.00  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem/512B/simd-4                                        34791368    31.10  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem/512B/default-4                                      4611427    257.6  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem/4096B/simd-4                                       11800508    103.1  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem/4096B/default-4                                      602314     2006  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/8B/paired-4                              80288234    14.78  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/8B/paired-stdlib-4                      128086692    9.383  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/32B/paired-4                             45365626    26.15  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/32B/paired-stdlib-4                      92536278    13.37  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/32B/single-4                             59111966    19.17  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/32B/single-stdlib-4                      71310552    17.81  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/64B/paired-4                             66204072    16.81  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/64B/paired-stdlib-4                      73791969    16.97  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/64B/single-4                             30604410    36.57  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/64B/single-stdlib-4                      31350355    39.58  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/96B/paired-4                             65701838    20.63  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/96B/paired-stdlib-4                      23252902    50.79  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/96B/single-4                             24038308    58.47  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/96B/single-stdlib-4                      30170570    39.71  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/128B/paired-4                            62815480    19.08  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/128B/paired-stdlib-4                     15175219    69.96  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/128B/single-4                            18564657    66.55  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/128B/single-stdlib-4                     23300037    51.97  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/192B/paired-4                            61017051    19.98  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/192B/paired-stdlib-4                     12996568    90.54  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/192B/single-4                            12651052    95.92  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/192B/single-stdlib-4                     13437505    82.20  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/512B/paired-4                            47879569    27.38  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/512B/paired-stdlib-4                      4657275    254.4  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/512B/single-4                             4382628    271.7  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/512B/single-stdlib-4                      4978489    242.9  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/4096B/paired-4                           12400435    95.11  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/4096B/paired-stdlib-4                      622046     1974  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/4096B/single-4                             589645     1991  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/4096B/single-stdlib-4                      597627     1942  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Adversarial/simd-4                                      727  1694665  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Adversarial/default-4                                   702  1691066  ns/op     0  B/op   0  allocs/op
-Benchmark_IsASCII/8B/simd-4                                        257560344    4.639  ns/op     0  B/op   0  allocs/op
-Benchmark_IsASCII/8B/swar-4                                        418198748    2.896  ns/op     0  B/op   0  allocs/op
-Benchmark_IsASCII/32B/simd-4                                       224330505    5.526  ns/op     0  B/op   0  allocs/op
-Benchmark_IsASCII/32B/swar-4                                       177624045    7.065  ns/op     0  B/op   0  allocs/op
-Benchmark_IsASCII/64B/simd-4                                       205050678    5.738  ns/op     0  B/op   0  allocs/op
-Benchmark_IsASCII/64B/swar-4                                       100000000    10.04  ns/op     0  B/op   0  allocs/op
-Benchmark_IsASCII/512B/simd-4                                      136601577    9.710  ns/op     0  B/op   0  allocs/op
-Benchmark_IsASCII/512B/swar-4                                       19524085    60.29  ns/op     0  B/op   0  allocs/op
-Benchmark_IsASCII/4096B/simd-4                                      32085013    36.26  ns/op     0  B/op   0  allocs/op
-Benchmark_IsASCII/4096B/swar-4                                       2544463    473.8  ns/op     0  B/op   0  allocs/op
-Benchmark_FirstNonASCII/8B/simd-4                                  190954252    6.270  ns/op     0  B/op   0  allocs/op
-Benchmark_FirstNonASCII/8B/swar-4                                  287893554    4.182  ns/op     0  B/op   0  allocs/op
-Benchmark_FirstNonASCII/32B/simd-4                                 216938428    5.010  ns/op     0  B/op   0  allocs/op
-Benchmark_FirstNonASCII/32B/swar-4                                 156548259    7.619  ns/op     0  B/op   0  allocs/op
-Benchmark_FirstNonASCII/64B/simd-4                                 213935623    5.797  ns/op     0  B/op   0  allocs/op
-Benchmark_FirstNonASCII/64B/swar-4                                  92908466    20.84  ns/op     0  B/op   0  allocs/op
-Benchmark_FirstNonASCII/512B/simd-4                                100000000    12.06  ns/op     0  B/op   0  allocs/op
-Benchmark_FirstNonASCII/512B/swar-4                                 13706763    84.51  ns/op     0  B/op   0  allocs/op
-Benchmark_FirstNonASCII/4096B/simd-4                                18738898    69.73  ns/op     0  B/op   0  allocs/op
-Benchmark_FirstNonASCII/4096B/swar-4                                 1920032    605.4  ns/op     0  B/op   0  allocs/op
-Benchmark_CountNonASCII/8B/simd-4                                  194997026    7.857  ns/op     0  B/op   0  allocs/op
-Benchmark_CountNonASCII/8B/swar-4                                  263451292    4.718  ns/op     0  B/op   0  allocs/op
-Benchmark_CountNonASCII/32B/simd-4                                 137009131    8.817  ns/op     0  B/op   0  allocs/op
-Benchmark_CountNonASCII/32B/swar-4                                 139627035    8.573  ns/op     0  B/op   0  allocs/op
-Benchmark_CountNonASCII/64B/simd-4                                 127258202    9.851  ns/op     0  B/op   0  allocs/op
-Benchmark_CountNonASCII/64B/swar-4                                  76861488    15.21  ns/op     0  B/op   0  allocs/op
-Benchmark_CountNonASCII/512B/simd-4                                 71510445    17.30  ns/op     0  B/op   0  allocs/op
-Benchmark_CountNonASCII/512B/swar-4                                 12760722    93.31  ns/op     0  B/op   0  allocs/op
-Benchmark_CountNonASCII/4096B/simd-4                                19135555    64.03  ns/op     0  B/op   0  allocs/op
-Benchmark_CountNonASCII/4096B/swar-4                                 1549219    772.8  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr2/8B/simd-4                                        166775934    6.955  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr2/8B/scalar-4                                      211595070    5.814  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr2/8B/default-4                                      30108765    36.02  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr2/32B/simd-4                                       188099018    6.475  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr2/32B/scalar-4                                     100000000    10.15  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr2/32B/default-4                                     25436731    45.07  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr2/64B/simd-4                                       160683514    7.316  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr2/64B/scalar-4                                      74313721    16.33  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr2/64B/default-4                                     20844832    55.97  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr2/512B/simd-4                                       81902580    14.97  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr2/512B/scalar-4                                     10329916    118.8  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr2/512B/default-4                                     3075676    393.0  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr2/4096B/simd-4                                      18102721    68.61  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr2/4096B/scalar-4                                     1416972    864.8  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr2/4096B/default-4                                     402018     2983  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr3/8B/simd-4                                        136411728    8.676  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr3/8B/scalar-4                                      154497250    7.486  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr3/8B/default-4                                      34597688    39.32  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr3/32B/simd-4                                       156686616    7.817  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr3/32B/scalar-4                                      85514072    14.02  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr3/32B/default-4                                     34173225    34.18  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr3/64B/simd-4                                       136311558    8.716  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr3/64B/scalar-4                                      49021902    23.70  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr3/64B/default-4                                     21518966    57.19  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr3/512B/simd-4                                       64916151    19.62  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr3/512B/scalar-4                                      7012357    162.1  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr3/512B/default-4                                     2803662    392.5  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr3/4096B/simd-4                                      11516102    98.47  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr3/4096B/scalar-4                                      967389     1233  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr3/4096B/default-4                                     372224     3004  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrPair/8B/simd-4                                     100000000    10.46  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrPair/8B/scalar-4                                   205322738    5.875  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrPair/32B/simd-4                                     55314021    20.89  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrPair/32B/scalar-4                                   57437145    21.17  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrPair/64B/simd-4                                    121543113    9.470  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrPair/64B/scalar-4                                   26435707    42.11  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrPair/512B/simd-4                                    54232755    19.35  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrPair/512B/scalar-4                                   2976901    347.0  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrPair/4096B/simd-4                                   13514536    88.98  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrPair/4096B/scalar-4                                   430855     2778  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrDigit/8B/simd-4                                    136738652    7.944  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrDigit/8B/scalar-4                                  209848646    5.301  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrDigit/32B/simd-4                                   180939722    6.379  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrDigit/32B/scalar-4                                 100000000    10.44  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrDigit/64B/simd-4                                   163112491    7.578  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrDigit/64B/scalar-4                                  69132280    16.96  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrDigit/512B/simd-4                                   82707004    14.48  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrDigit/512B/scalar-4                                  9733840    133.2  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrDigit/4096B/simd-4                                  15429883    81.41  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrDigit/4096B/scalar-4                                 1316628    923.9  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrWord/8B/simd-4                                     100000000    10.39  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrWord/8B/scalar-4                                   137844606    8.635  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrWord/32B/simd-4                                    171564747    7.032  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrWord/32B/scalar-4                                   49735075    23.14  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrWord/64B/simd-4                                    146017768    8.557  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrWord/64B/scalar-4                                   24390914    43.91  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrWord/512B/simd-4                                    61057335    19.83  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrWord/512B/scalar-4                                   2999950    351.0  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrWord/4096B/simd-4                                   10848006    111.5  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrWord/4096B/scalar-4                                   420418     2717  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrNotWord/8B/simd-4                                  100000000    10.44  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrNotWord/8B/scalar-4                                129633012    9.306  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrNotWord/32B/simd-4                                 165562329    7.131  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrNotWord/32B/scalar-4                                45987835    27.13  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrNotWord/64B/simd-4                                 132951244    8.781  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrNotWord/64B/scalar-4                                24562381    49.54  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrNotWord/512B/simd-4                                 61239534    19.62  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrNotWord/512B/scalar-4                                3130172    376.6  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrNotWord/4096B/simd-4                                11077279    113.2  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrNotWord/4096B/scalar-4                                413086     3276  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem/8B/simd-4                                         100000000    10.99  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem/8B/default-4                                      133027675    9.593  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem/32B/simd-4                                         78421987    15.82  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem/32B/default-4                                      93988635    13.69  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem/64B/simd-4                                         63327909    19.84  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem/64B/default-4                                      68144829    16.73  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem/96B/simd-4                                         22108604    52.85  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem/96B/default-4                                      24109950    50.79  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem/128B/simd-4                                        46320181    24.47  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem/128B/default-4                                     16147812    64.02  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem/192B/simd-4                                        44552890    25.76  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem/192B/default-4                                     13128886    96.02  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem/512B/simd-4                                        35403554    32.31  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem/512B/default-4                                      4572046    267.1  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem/4096B/simd-4                                       11817771    112.8  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem/4096B/default-4                                      564676     2018  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/8B/paired-4                              74481417    14.55  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/8B/paired-stdlib-4                      132872514    9.482  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/32B/paired-4                             46307214    26.30  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/32B/paired-stdlib-4                      93691669    12.92  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/32B/single-4                             69403665    17.82  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/32B/single-stdlib-4                      72063870    17.05  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/64B/paired-4                             68429199    16.65  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/64B/paired-stdlib-4                      74431048    16.54  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/64B/single-4                             31007065    38.97  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/64B/single-stdlib-4                      30941724    40.61  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/96B/paired-4                             65736357    19.59  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/96B/paired-stdlib-4                      22522497    51.35  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/96B/single-4                             24870852    48.59  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/96B/single-stdlib-4                      29714346    43.42  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/128B/paired-4                            51420790    19.82  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/128B/paired-stdlib-4                     19055680    67.65  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/128B/single-4                            16195831    77.24  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/128B/single-stdlib-4                     23495053    52.67  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/192B/paired-4                            58638885    19.92  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/192B/paired-stdlib-4                     12657384    92.47  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/192B/single-4                            11716906    97.63  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/192B/single-stdlib-4                     14966446    82.35  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/512B/paired-4                            45954300    26.91  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/512B/paired-stdlib-4                      4483488    262.9  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/512B/single-4                             4513759    268.3  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/512B/single-stdlib-4                      4918275    243.2  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/4096B/paired-4                           11952480    97.35  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/4096B/paired-stdlib-4                      525157     2004  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/4096B/single-4                             607122     1988  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/4096B/single-stdlib-4                      621241     1973  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Adversarial/simd-4                                      698  1715647  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Adversarial/default-4                                   718  1696956  ns/op     0  B/op   0  allocs/op
+Benchmark_IsASCII/8B/simd-4                                        253699356    4.888  ns/op     0  B/op   0  allocs/op
+Benchmark_IsASCII/8B/swar-4                                        390683442    2.872  ns/op     0  B/op   0  allocs/op
+Benchmark_IsASCII/32B/simd-4                                       234724498    5.305  ns/op     0  B/op   0  allocs/op
+Benchmark_IsASCII/32B/swar-4                                       247579681    4.774  ns/op     0  B/op   0  allocs/op
+Benchmark_IsASCII/64B/simd-4                                       196755495    5.838  ns/op     0  B/op   0  allocs/op
+Benchmark_IsASCII/64B/swar-4                                       200039208    6.085  ns/op     0  B/op   0  allocs/op
+Benchmark_IsASCII/512B/simd-4                                      134683416    8.874  ns/op     0  B/op   0  allocs/op
+Benchmark_IsASCII/512B/swar-4                                       52244253    23.74  ns/op     0  B/op   0  allocs/op
+Benchmark_IsASCII/4096B/simd-4                                      31798422    36.09  ns/op     0  B/op   0  allocs/op
+Benchmark_IsASCII/4096B/swar-4                                       6289762    185.5  ns/op     0  B/op   0  allocs/op
+Benchmark_FirstNonASCII/8B/simd-4                                  167846630    6.921  ns/op     0  B/op   0  allocs/op
+Benchmark_FirstNonASCII/8B/swar-4                                  274941226    4.198  ns/op     0  B/op   0  allocs/op
+Benchmark_FirstNonASCII/32B/simd-4                                 230169858    5.258  ns/op     0  B/op   0  allocs/op
+Benchmark_FirstNonASCII/32B/swar-4                                 201038061    5.939  ns/op     0  B/op   0  allocs/op
+Benchmark_FirstNonASCII/64B/simd-4                                 202030548    5.904  ns/op     0  B/op   0  allocs/op
+Benchmark_FirstNonASCII/64B/swar-4                                 155556992    7.710  ns/op     0  B/op   0  allocs/op
+Benchmark_FirstNonASCII/512B/simd-4                                 96933100    12.02  ns/op     0  B/op   0  allocs/op
+Benchmark_FirstNonASCII/512B/swar-4                                 23106508    51.56  ns/op     0  B/op   0  allocs/op
+Benchmark_FirstNonASCII/4096B/simd-4                                18463803    65.99  ns/op     0  B/op   0  allocs/op
+Benchmark_FirstNonASCII/4096B/swar-4                                 3403281    340.4  ns/op     0  B/op   0  allocs/op
+Benchmark_CountNonASCII/8B/simd-4                                  187364193    6.482  ns/op     0  B/op   0  allocs/op
+Benchmark_CountNonASCII/8B/swar-4                                  238375552    4.760  ns/op     0  B/op   0  allocs/op
+Benchmark_CountNonASCII/32B/simd-4                                 178751967    6.643  ns/op     0  B/op   0  allocs/op
+Benchmark_CountNonASCII/32B/swar-4                                 181234458    6.927  ns/op     0  B/op   0  allocs/op
+Benchmark_CountNonASCII/64B/simd-4                                 168405226    6.951  ns/op     0  B/op   0  allocs/op
+Benchmark_CountNonASCII/64B/swar-4                                 100000000    10.22  ns/op     0  B/op   0  allocs/op
+Benchmark_CountNonASCII/512B/simd-4                                 75394282    13.91  ns/op     0  B/op   0  allocs/op
+Benchmark_CountNonASCII/512B/swar-4                                 23672272    51.57  ns/op     0  B/op   0  allocs/op
+Benchmark_CountNonASCII/4096B/simd-4                                19620422    60.02  ns/op     0  B/op   0  allocs/op
+Benchmark_CountNonASCII/4096B/swar-4                                 2849376    419.4  ns/op     0  B/op   0  allocs/op
 ```
 
 <!-- skip-docs -->

--- a/README.md
+++ b/README.md
@@ -686,7 +686,13 @@ reach them but skip the 128-byte block loop, so they pay its setup with
 nothing to amortize it against: across that band `benchstat` reports the
 class scans clearly ahead (`MemchrNotWord` -8.6% at 32B, -18.4% at 64B;
 `IsASCII` -5.0%/-4.3%), most rows statistically unchanged, and two small
-regressions — `MemchrDigit` +5.6% at 32B and `Memchr3` +3.8% at 64B.
+regressions — `MemchrDigit` +5.6% at 32B and `Memchr3` +3.8% at 64B. Read
+those small-input figures against the run's own noise floor: the `default`
+legs call unchanged stdlib code, so their movement bounds what a delta of
+that size means. They held within 1% in the run quoted here, but a later
+run on the same machine drifted up to 17% on those same rows, so anything
+under ~10% at 32-64B should be taken as "no measured change" unless its
+control legs are quiet.
 
 On the portable side, pinning each unrolled group of words with a reslice
 before loading at constant offsets inside it removes the per-load bounds

--- a/README.md
+++ b/README.md
@@ -613,25 +613,29 @@ it is deliberately not part of the catalog above.
 ## SIMD-accelerated search (package simd)
 
 The [`simd`](simd/) package is the vector-width counterpart to `swar`: byte
-searching and validation whose scan kernels dispatch to AVX2 assembly (32
-bytes per iteration) on amd64 CPUs for inputs of `simd.MinLen` (32) bytes
-or more, and fall back to portable loops built on the `swar` primitives
-everywhere else, so it builds and behaves identically on every platform.
+searching and validation whose scan kernels dispatch to AVX2 assembly (four
+32-byte vectors per iteration) on amd64 CPUs for inputs of `simd.MinLen`
+(32) bytes or more, and fall back to portable loops built on the `swar`
+primitives everywhere else, so it builds and behaves identically on every
+platform.
 `simd.Accelerated()` reports which mode is active. CPU capability detection
 uses [`golang.org/x/sys/cpu`](https://pkg.go.dev/golang.org/x/sys/cpu),
 which also verifies OS support for saving the vector register state.
 
 The AVX2-backed kernels are the multi-needle scans (`Memchr2`, `Memchr3`),
 the paired-byte scan (`MemchrPair`), the class scans
-(`MemchrDigit`/`MemchrDigitAt`, `MemchrWord`/`MemchrNotWord`), ASCII
-validation (`IsASCII`), and the substring search (`Memmem`), which
+(`MemchrDigit`/`MemchrDigitAt`, `MemchrWord`/`MemchrNotWord`), the ASCII
+scans (`IsASCII`, `FirstNonASCII`, `CountNonASCII`), and the substring
+search (`Memmem`), which
 prefilters on the needle's rarest bytes (`SelectRareBytes`, `ByteRank`)
 before verifying candidates — 2-6 byte needles containing two distinct
 values are scanned for their two rarest bytes at the exact relative
 distance, longer or single-valued needles for the single rarest byte.
-Two smaller tiers are documented explicitly:
-`FirstNonASCII` and `CountNonASCII` are SWAR-only (8 bytes per iteration,
-no assembly kernel), and `MemchrInTable`/`MemchrNotInTable` are plain
+Each kernel classifies four 32-byte vectors per iteration and combines
+their masks, so a 128-byte block costs a single `VPMOVMSKB` and a single
+branch; the first-match scans then re-extract the four masks in address
+order on the (rare) hit path to locate the match. One tier is documented
+explicitly as unaccelerated: `MemchrInTable`/`MemchrNotInTable` are plain
 scalar loops, since an arbitrary 256-entry membership test has no cheap
 vector form. There is deliberately no single-needle `Memchr`:
 `bytes.IndexByte` is already vector-accelerated by the Go runtime. `Memmem`
@@ -654,9 +658,25 @@ contributors; see [`simd/LICENSE`](simd/LICENSE)), with the legacy-SSE
 register moves in the kernels replaced by VEX-encoded ones to avoid AVX-SSE
 transition stalls, the scalar tail loops replaced by overlapping vector
 rescans at the buffer end (a 63-byte scan previously cost ~3.7x a 64-byte
-one), and
+one), the 32-byte main loops replaced by 4x unrolled 128-byte blocks whose
+bound is tested once at the bottom against a precomputed limit pointer, the
+`\w` classifier rewritten from three `VPMINUB`/`VPMAXUB` clamp-and-compare
+range tests into two `VPSHUFB` nibble-table lookups, `FirstNonASCII` and
+`CountNonASCII` given kernels of their own (they were SWAR-only), and
 the fallbacks reworked around the stdlib and the `swar` package as
 described above.
+
+Against the pre-unrolling kernels, `benchstat -count=10` on the machine
+below reports -26.6%/-49.7% ns/op for `Memchr2` at 512B/4096B,
+-17.6%/-34.3% for `Memchr3`, -13.4%/-24.6% for `MemchrPair`,
+-39.2%/-50.5% for `MemchrDigit`, -53.5%/-63.7% for `MemchrNotWord`,
+-42.2%/-65.7% for `IsASCII`, and -13.7%/-27.1% for `Memmem`, which rides
+the paired scan; sub-vector inputs are unchanged, since they never reach
+the kernels. The two portable-fallback changes that survived measurement
+are the ASCII scan (-25% at 8B, -32% at 4096B) and the digit scan (-12%
+to -17% from 32B up); unrolling the multi-needle, `\w` and counting
+fallbacks measured neutral to worse in a same-process A/B, so those keep
+their single-word loops.
 
 Because the AVX2 kernels only engage on amd64, their benchmark numbers are
 recorded separately from the arm64 catalog above:
@@ -669,114 +689,154 @@ cpu: Intel(R) Xeon(R) Processor @ 2.80GHz (AVX2)
 
 ```text
 // go test ./simd/ -benchmem -run=^$ -bench=Benchmark_ -count=1
-Benchmark_Memchr2/8B/simd-4                                        160932234    7.510  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr2/8B/default-4                                      31407770    39.39  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr2/32B/simd-4                                       180379407    7.463  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr2/32B/default-4                                     28221582    42.47  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr2/64B/simd-4                                       170949894    6.883  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr2/64B/default-4                                     21863884    57.19  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr2/512B/simd-4                                       59448526    21.04  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr2/512B/default-4                                     3130293    391.1  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr2/4096B/simd-4                                      10117922    117.0  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr2/4096B/default-4                                     412353     3055  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr3/8B/simd-4                                        141613051    7.994  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr3/8B/default-4                                      29630468    40.43  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr3/32B/simd-4                                       171311121    6.895  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr3/32B/default-4                                     30218668    40.41  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr3/64B/simd-4                                       150505892    7.856  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr3/64B/default-4                                     19079786    64.43  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr3/512B/simd-4                                       52560612    23.74  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr3/512B/default-4                                     3086830    388.6  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr3/4096B/simd-4                                       7735116    150.1  ns/op     0  B/op   0  allocs/op
-Benchmark_Memchr3/4096B/default-4                                     400952     2975  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrPair/8B/simd-4                                      89391540    12.82  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrPair/8B/scalar-4                                   216545959    5.584  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrPair/32B/simd-4                                     54730342    21.36  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrPair/32B/scalar-4                                   56326855    21.45  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrPair/64B/simd-4                                    100000000    10.74  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrPair/64B/scalar-4                                   27203602    44.19  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrPair/512B/simd-4                                    55834921    21.79  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrPair/512B/scalar-4                                   3446038    342.1  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrPair/4096B/simd-4                                    9817900    122.1  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrPair/4096B/scalar-4                                   445594     2675  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrDigit/8B/simd-4                                    169659172    7.221  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrDigit/8B/scalar-4                                  234911584    5.033  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrDigit/32B/simd-4                                   174639595    7.164  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrDigit/32B/scalar-4                                  89061945    12.65  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrDigit/64B/simd-4                                   151388893    7.846  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrDigit/64B/scalar-4                                  52860561    23.28  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrDigit/512B/simd-4                                   47377659    25.40  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrDigit/512B/scalar-4                                  7123378    168.5  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrDigit/4096B/simd-4                                   6884252    176.9  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrDigit/4096B/scalar-4                                  884161     1317  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrNotWord/8B/simd-4                                  100000000    10.07  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrNotWord/8B/scalar-4                                134836845    8.672  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrNotWord/32B/simd-4                                 149667877    8.193  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrNotWord/32B/scalar-4                                44375330    26.63  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrNotWord/64B/simd-4                                 100000000    10.22  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrNotWord/64B/scalar-4                                23879234    50.68  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrNotWord/512B/simd-4                                 22524218    46.90  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrNotWord/512B/scalar-4                                2931174    408.6  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrNotWord/4096B/simd-4                                 3752906    335.2  ns/op     0  B/op   0  allocs/op
-Benchmark_MemchrNotWord/4096B/scalar-4                                345715     3136  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem/8B/simd-4                                         100000000    11.61  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem/8B/default-4                                      134337361    9.246  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem/32B/simd-4                                         73584829    15.61  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem/32B/default-4                                      88738117    13.46  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem/64B/simd-4                                         61874611    19.30  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem/64B/default-4                                      74323999    16.76  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem/96B/simd-4                                         22135388    63.57  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem/96B/default-4                                      23687415    50.17  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem/128B/simd-4                                        47676351    24.76  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem/128B/default-4                                     19612291    60.68  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem/192B/simd-4                                        47072698    26.98  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem/192B/default-4                                     11572932    100.1  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem/512B/simd-4                                        34756200    36.05  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem/512B/default-4                                      4604108    261.4  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem/4096B/simd-4                                        8868234    135.8  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem/4096B/default-4                                      613701     1962  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/8B/paired-4                              86125052    14.52  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/8B/paired-stdlib-4                      136569471    9.120  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/32B/paired-4                             46744827    25.76  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/32B/paired-stdlib-4                      95989609    12.81  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/32B/single-4                             69678790    17.61  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/32B/single-stdlib-4                      68305318    18.38  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/64B/paired-4                             64893210    17.20  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/64B/paired-stdlib-4                      70806460    16.34  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/64B/single-4                             34043565    36.62  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/64B/single-stdlib-4                      24664317    47.43  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/96B/paired-4                             67596938    19.75  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/96B/paired-stdlib-4                      21772609    50.35  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/96B/single-4                             25962633    47.83  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/96B/single-stdlib-4                      31263175    38.29  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/128B/paired-4                            65862615    18.80  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/128B/paired-stdlib-4                     18729648    64.33  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/128B/single-4                            18243868    65.45  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/128B/single-stdlib-4                     23761232    51.21  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/192B/paired-4                            60481297    20.08  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/192B/paired-stdlib-4                     13275300    93.19  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/192B/single-4                            11936652    102.1  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/192B/single-stdlib-4                     14467984    83.21  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/512B/paired-4                            42353164    28.11  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/512B/paired-stdlib-4                      4483054    258.0  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/512B/single-4                             4454024    282.8  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/512B/single-stdlib-4                      4753104    251.3  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/4096B/paired-4                            9504126    124.9  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/4096B/paired-stdlib-4                      613930     1985  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/4096B/single-4                             563440     1980  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Prefilter/4096B/single-stdlib-4                      591222     1924  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Adversarial/simd-4                                      715  1698023  ns/op     0  B/op   0  allocs/op
-Benchmark_Memmem_Adversarial/default-4                                   722  1722337  ns/op     0  B/op   0  allocs/op
-Benchmark_IsASCII/8B/simd-4                                        211383338    5.542  ns/op     0  B/op   0  allocs/op
-Benchmark_IsASCII/8B/swar-4                                        316762524    4.007  ns/op     0  B/op   0  allocs/op
-Benchmark_IsASCII/32B/simd-4                                       240245251    5.077  ns/op     0  B/op   0  allocs/op
-Benchmark_IsASCII/32B/swar-4                                       164716737    7.257  ns/op     0  B/op   0  allocs/op
-Benchmark_IsASCII/64B/simd-4                                       191159047    6.444  ns/op     0  B/op   0  allocs/op
-Benchmark_IsASCII/64B/swar-4                                        88207845    12.81  ns/op     0  B/op   0  allocs/op
-Benchmark_IsASCII/512B/simd-4                                       75486206    14.96  ns/op     0  B/op   0  allocs/op
-Benchmark_IsASCII/512B/swar-4                                       14351298    90.64  ns/op     0  B/op   0  allocs/op
-Benchmark_IsASCII/4096B/simd-4                                      11831648    101.2  ns/op     0  B/op   0  allocs/op
-Benchmark_IsASCII/4096B/swar-4                                       1512061    685.9  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr2/8B/simd-4                                        165315782    7.315  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr2/8B/swar-4                                        196491015    6.137  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr2/8B/default-4                                      28966648    40.60  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr2/32B/simd-4                                       187528609    6.549  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr2/32B/swar-4                                        89646259    13.05  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr2/32B/default-4                                     28096137    45.91  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr2/64B/simd-4                                       158776046    7.623  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr2/64B/swar-4                                        57170502    21.78  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr2/64B/default-4                                     20759750    61.65  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr2/512B/simd-4                                       77927769    16.00  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr2/512B/swar-4                                        7770205    156.9  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr2/512B/default-4                                     3071950    402.4  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr2/4096B/simd-4                                      17414829    72.99  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr2/4096B/swar-4                                       1000000     1244  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr2/4096B/default-4                                     379147     3146  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr3/8B/simd-4                                        147468846    8.341  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr3/8B/swar-4                                        176507472    6.800  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr3/8B/default-4                                      28842992    40.00  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr3/32B/simd-4                                       160795072    7.650  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr3/32B/swar-4                                        78000026    15.53  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr3/32B/default-4                                     26226373    44.36  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr3/64B/simd-4                                       142414808    8.458  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr3/64B/swar-4                                        43815084    27.48  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr3/64B/default-4                                     18827344    71.12  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr3/512B/simd-4                                       60840774    19.69  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr3/512B/swar-4                                        5980300    188.4  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr3/512B/default-4                                     3097173    435.4  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr3/4096B/simd-4                                      11583232    97.17  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr3/4096B/swar-4                                        819153     1531  ns/op     0  B/op   0  allocs/op
+Benchmark_Memchr3/4096B/default-4                                     390268     2998  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrPair/8B/simd-4                                      91713038    12.58  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrPair/8B/scalar-4                                   204832017    6.559  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrPair/32B/simd-4                                     58506270    21.13  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrPair/32B/scalar-4                                   57385882    21.93  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrPair/64B/simd-4                                    127400613    9.210  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrPair/64B/scalar-4                                   29796430    41.77  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrPair/512B/simd-4                                    62287556    18.71  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrPair/512B/scalar-4                                   2986849    349.1  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrPair/4096B/simd-4                                   12880382    94.26  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrPair/4096B/scalar-4                                   451850     2679  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrDigit/8B/simd-4                                    183451314    6.513  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrDigit/8B/scalar-4                                  212146264    5.553  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrDigit/32B/simd-4                                   187313154    6.495  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrDigit/32B/scalar-4                                 100000000    10.90  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrDigit/64B/simd-4                                   160148972    7.463  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrDigit/64B/scalar-4                                  56653626    22.08  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrDigit/512B/simd-4                                   76820638    15.60  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrDigit/512B/scalar-4                                  8258727    149.2  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrDigit/4096B/simd-4                                  13186258    87.90  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrDigit/4096B/scalar-4                                 1000000     1199  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrWord/8B/simd-4                                     100000000    11.21  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrWord/8B/scalar-4                                   128865920    8.660  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrWord/32B/simd-4                                    169381110    6.996  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrWord/32B/scalar-4                                   37175652    33.52  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrWord/64B/simd-4                                    141170670    8.620  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrWord/64B/scalar-4                                   22469738    48.16  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrWord/512B/simd-4                                    59720695    20.28  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrWord/512B/scalar-4                                   3151227    390.4  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrWord/4096B/simd-4                                   10121071    117.0  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrWord/4096B/scalar-4                                   403077     3049  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrNotWord/8B/simd-4                                  118039993    9.757  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrNotWord/8B/scalar-4                                150062998    8.823  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrNotWord/32B/simd-4                                 149304132    7.276  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrNotWord/32B/scalar-4                                45402106    26.49  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrNotWord/64B/simd-4                                 128084203    8.693  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrNotWord/64B/scalar-4                                23453022    52.32  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrNotWord/512B/simd-4                                 55942212    19.85  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrNotWord/512B/scalar-4                                3025902    417.7  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrNotWord/4096B/simd-4                                10867442    112.6  ns/op     0  B/op   0  allocs/op
+Benchmark_MemchrNotWord/4096B/scalar-4                                343974     3397  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem/8B/simd-4                                         100000000    11.52  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem/8B/default-4                                      133979869    8.818  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem/32B/simd-4                                         77301547    15.97  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem/32B/default-4                                      94086402    12.82  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem/64B/simd-4                                         60822933    19.05  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem/64B/default-4                                      71626387    16.13  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem/96B/simd-4                                         23305447    52.33  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem/96B/default-4                                      22869541    52.19  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem/128B/simd-4                                        50354059    24.64  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem/128B/default-4                                     19627141    66.74  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem/192B/simd-4                                        43966809    26.97  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem/192B/default-4                                     12731815    92.00  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem/512B/simd-4                                        34791368    31.10  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem/512B/default-4                                      4611427    257.6  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem/4096B/simd-4                                       11800508    103.1  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem/4096B/default-4                                      602314     2006  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/8B/paired-4                              80288234    14.78  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/8B/paired-stdlib-4                      128086692    9.383  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/32B/paired-4                             45365626    26.15  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/32B/paired-stdlib-4                      92536278    13.37  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/32B/single-4                             59111966    19.17  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/32B/single-stdlib-4                      71310552    17.81  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/64B/paired-4                             66204072    16.81  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/64B/paired-stdlib-4                      73791969    16.97  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/64B/single-4                             30604410    36.57  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/64B/single-stdlib-4                      31350355    39.58  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/96B/paired-4                             65701838    20.63  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/96B/paired-stdlib-4                      23252902    50.79  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/96B/single-4                             24038308    58.47  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/96B/single-stdlib-4                      30170570    39.71  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/128B/paired-4                            62815480    19.08  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/128B/paired-stdlib-4                     15175219    69.96  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/128B/single-4                            18564657    66.55  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/128B/single-stdlib-4                     23300037    51.97  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/192B/paired-4                            61017051    19.98  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/192B/paired-stdlib-4                     12996568    90.54  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/192B/single-4                            12651052    95.92  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/192B/single-stdlib-4                     13437505    82.20  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/512B/paired-4                            47879569    27.38  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/512B/paired-stdlib-4                      4657275    254.4  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/512B/single-4                             4382628    271.7  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/512B/single-stdlib-4                      4978489    242.9  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/4096B/paired-4                           12400435    95.11  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/4096B/paired-stdlib-4                      622046     1974  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/4096B/single-4                             589645     1991  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Prefilter/4096B/single-stdlib-4                      597627     1942  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Adversarial/simd-4                                      727  1694665  ns/op     0  B/op   0  allocs/op
+Benchmark_Memmem_Adversarial/default-4                                   702  1691066  ns/op     0  B/op   0  allocs/op
+Benchmark_IsASCII/8B/simd-4                                        257560344    4.639  ns/op     0  B/op   0  allocs/op
+Benchmark_IsASCII/8B/swar-4                                        418198748    2.896  ns/op     0  B/op   0  allocs/op
+Benchmark_IsASCII/32B/simd-4                                       224330505    5.526  ns/op     0  B/op   0  allocs/op
+Benchmark_IsASCII/32B/swar-4                                       177624045    7.065  ns/op     0  B/op   0  allocs/op
+Benchmark_IsASCII/64B/simd-4                                       205050678    5.738  ns/op     0  B/op   0  allocs/op
+Benchmark_IsASCII/64B/swar-4                                       100000000    10.04  ns/op     0  B/op   0  allocs/op
+Benchmark_IsASCII/512B/simd-4                                      136601577    9.710  ns/op     0  B/op   0  allocs/op
+Benchmark_IsASCII/512B/swar-4                                       19524085    60.29  ns/op     0  B/op   0  allocs/op
+Benchmark_IsASCII/4096B/simd-4                                      32085013    36.26  ns/op     0  B/op   0  allocs/op
+Benchmark_IsASCII/4096B/swar-4                                       2544463    473.8  ns/op     0  B/op   0  allocs/op
+Benchmark_FirstNonASCII/8B/simd-4                                  190954252    6.270  ns/op     0  B/op   0  allocs/op
+Benchmark_FirstNonASCII/8B/swar-4                                  287893554    4.182  ns/op     0  B/op   0  allocs/op
+Benchmark_FirstNonASCII/32B/simd-4                                 216938428    5.010  ns/op     0  B/op   0  allocs/op
+Benchmark_FirstNonASCII/32B/swar-4                                 156548259    7.619  ns/op     0  B/op   0  allocs/op
+Benchmark_FirstNonASCII/64B/simd-4                                 213935623    5.797  ns/op     0  B/op   0  allocs/op
+Benchmark_FirstNonASCII/64B/swar-4                                  92908466    20.84  ns/op     0  B/op   0  allocs/op
+Benchmark_FirstNonASCII/512B/simd-4                                100000000    12.06  ns/op     0  B/op   0  allocs/op
+Benchmark_FirstNonASCII/512B/swar-4                                 13706763    84.51  ns/op     0  B/op   0  allocs/op
+Benchmark_FirstNonASCII/4096B/simd-4                                18738898    69.73  ns/op     0  B/op   0  allocs/op
+Benchmark_FirstNonASCII/4096B/swar-4                                 1920032    605.4  ns/op     0  B/op   0  allocs/op
+Benchmark_CountNonASCII/8B/simd-4                                  194997026    7.857  ns/op     0  B/op   0  allocs/op
+Benchmark_CountNonASCII/8B/swar-4                                  263451292    4.718  ns/op     0  B/op   0  allocs/op
+Benchmark_CountNonASCII/32B/simd-4                                 137009131    8.817  ns/op     0  B/op   0  allocs/op
+Benchmark_CountNonASCII/32B/swar-4                                 139627035    8.573  ns/op     0  B/op   0  allocs/op
+Benchmark_CountNonASCII/64B/simd-4                                 127258202    9.851  ns/op     0  B/op   0  allocs/op
+Benchmark_CountNonASCII/64B/swar-4                                  76861488    15.21  ns/op     0  B/op   0  allocs/op
+Benchmark_CountNonASCII/512B/simd-4                                 71510445    17.30  ns/op     0  B/op   0  allocs/op
+Benchmark_CountNonASCII/512B/swar-4                                 12760722    93.31  ns/op     0  B/op   0  allocs/op
+Benchmark_CountNonASCII/4096B/simd-4                                19135555    64.03  ns/op     0  B/op   0  allocs/op
+Benchmark_CountNonASCII/4096B/swar-4                                 1549219    772.8  ns/op     0  B/op   0  allocs/op
 ```
 
 <!-- skip-docs -->

--- a/ascii.go
+++ b/ascii.go
@@ -20,20 +20,38 @@ const (
 
 // IsASCII reports whether s contains only ASCII bytes (no byte >= 0x80).
 // It ORs four words per iteration where possible (no index is needed, so
-// detection can be deferred to one test per 32 bytes), then tests word-wise;
-// inputs of 8+ bytes finish with one overlapping word at n-8, shorter ones
-// byte-wise.
+// detection can be deferred to one test per 32 bytes), then two, then
+// word-wise; inputs of 8+ bytes finish with one overlapping word at n-8,
+// shorter ones byte-wise.
 // On amd64 CPUs with AVX2, inputs of 32+ bytes dispatch to package simd
 // instead.
+//
+// The unrolled loops pin their group of words with a reslice and load at
+// constant offsets inside it. swar.Load8's own reslice is bounds-checked
+// against the backing array, which the length-based loop condition does
+// not imply, so a variable index costs a compare and a branch per load;
+// pinning the window pays that once per group instead. This mirrors
+// simd.isASCIIGeneric — the same scan, kept in step so a retune of either
+// is a retune of both.
 func IsASCII[S byteSeq](s S) bool {
 	n := len(s)
 	if n >= simd.MinLen && simd.Accelerated() {
 		return simd.IsASCII(unsafeconv.Bytes(s))
 	}
+	if n >= 8 && n < 16 {
+		return (swar.Load8(s, 0)|swar.Load8(s, n-8))&swar.HighBits == 0
+	}
 	i := 0
 	for ; i+32 <= n; i += 32 {
-		acc := swar.Load8(s, i) | swar.Load8(s, i+8) | swar.Load8(s, i+16) | swar.Load8(s, i+24)
+		w := s[i : i+32]
+		acc := swar.Load8(w, 0) | swar.Load8(w, 8) | swar.Load8(w, 16) | swar.Load8(w, 24)
 		if acc&swar.HighBits != 0 {
+			return false
+		}
+	}
+	for ; i+16 <= n; i += 16 {
+		w := s[i : i+16]
+		if (swar.Load8(w, 0)|swar.Load8(w, 8))&swar.HighBits != 0 {
 			return false
 		}
 	}
@@ -70,8 +88,11 @@ func IndexNonQuotable[S byteSeq](s S) int {
 	// Two words per branch: the masks compute independently, and if only the
 	// second word matched, its first set lane is still exact.
 	for ; i+16 <= n; i += 16 {
-		m0 := nonQuotableMask(swar.Load8(s, i))
-		m1 := nonQuotableMask(swar.Load8(s, i+8))
+		// Pinned window, as in IsASCII above: the two loads land at
+		// constant offsets and skip their bounds checks.
+		w := s[i : i+16]
+		m0 := nonQuotableMask(swar.Load8(w, 0))
+		m1 := nonQuotableMask(swar.Load8(w, 8))
 		if m0|m1 != 0 {
 			if m0 != 0 {
 				return i + swar.FirstLane(m0)

--- a/simd/ascii.go
+++ b/simd/ascii.go
@@ -47,6 +47,16 @@ func CountNonASCII(data []byte) int {
 	return countNonASCIIImpl(data)
 }
 
+// The unrolled loops below all pin their group of words with a
+// three-index reslice before loading from it. swar.Load8's own reslice is
+// bounds-checked against the backing array's capacity, which the loop
+// condition (stated in terms of length) does not imply, so a variable
+// index costs a compare, a branch and a four-instruction empty-slice
+// pointer clamp per load. Pinning the window once pays that at group
+// granularity and leaves the loads inside it at constant offsets, where
+// the checks fold away entirely: measured -20% at 32B rising to -62% at
+// 4KiB for the ASCII scan, and the same shape for the first-match scans.
+
 // isASCIIGeneric is the portable SWAR implementation behind IsASCII. No
 // index is needed, so detection can be deferred: whole groups of words are
 // OR-ed into one accumulator and tested once, four words per branch and
@@ -69,16 +79,18 @@ func isASCIIGeneric(data []byte) bool {
 	}
 	i := 0
 	for ; i+4*swar.WordLen <= n; i += 4 * swar.WordLen {
-		acc := swar.Load8(data, i) |
-			swar.Load8(data, i+swar.WordLen) |
-			swar.Load8(data, i+2*swar.WordLen) |
-			swar.Load8(data, i+3*swar.WordLen)
+		w := data[i : i+4*swar.WordLen : i+4*swar.WordLen]
+		acc := swar.Load8(w, 0) |
+			swar.Load8(w, swar.WordLen) |
+			swar.Load8(w, 2*swar.WordLen) |
+			swar.Load8(w, 3*swar.WordLen)
 		if acc&swar.HighBits != 0 {
 			return false
 		}
 	}
 	for ; i+2*swar.WordLen <= n; i += 2 * swar.WordLen {
-		if (swar.Load8(data, i)|swar.Load8(data, i+swar.WordLen))&swar.HighBits != 0 {
+		w := data[i : i+2*swar.WordLen : i+2*swar.WordLen]
+		if (swar.Load8(w, 0)|swar.Load8(w, swar.WordLen))&swar.HighBits != 0 {
 			return false
 		}
 	}
@@ -107,8 +119,9 @@ func firstNonASCIIGeneric(data []byte) int {
 	}
 	i := 0
 	for ; i+2*swar.WordLen <= n; i += 2 * swar.WordLen {
-		m0 := swar.Load8(data, i) & swar.HighBits
-		m1 := swar.Load8(data, i+swar.WordLen) & swar.HighBits
+		w := data[i : i+2*swar.WordLen : i+2*swar.WordLen]
+		m0 := swar.Load8(w, 0) & swar.HighBits
+		m1 := swar.Load8(w, swar.WordLen) & swar.HighBits
 		if m0|m1 != 0 {
 			if m0 != 0 {
 				return i + swar.FirstLane(m0)
@@ -133,14 +146,21 @@ func firstNonASCIIGeneric(data []byte) int {
 }
 
 // countNonASCIIGeneric is the portable SWAR implementation behind
-// CountNonASCII: a popcount of the 0x80 lane bits per word. Unlike the
-// first-match scans it is not unrolled — the per-word popcount already
-// keeps the pipeline busy, and splitting the sum across accumulators
-// measured slower.
+// CountNonASCII: a popcount of the 0x80 lane bits per word, four words per
+// pinned window. Every word has to be visited whatever happens, so unlike
+// the first-match scans there is no branch to amortize — the win here is
+// purely the bounds checks the window removes.
 func countNonASCIIGeneric(data []byte) int {
 	count := 0
 	i := 0
 	n := len(data)
+	for ; i+4*swar.WordLen <= n; i += 4 * swar.WordLen {
+		w := data[i : i+4*swar.WordLen : i+4*swar.WordLen]
+		count += bits.OnesCount64(swar.Load8(w, 0)&swar.HighBits) +
+			bits.OnesCount64(swar.Load8(w, swar.WordLen)&swar.HighBits) +
+			bits.OnesCount64(swar.Load8(w, 2*swar.WordLen)&swar.HighBits) +
+			bits.OnesCount64(swar.Load8(w, 3*swar.WordLen)&swar.HighBits)
+	}
 	for ; i+swar.WordLen <= n; i += swar.WordLen {
 		count += bits.OnesCount64(swar.Load8(data, i) & swar.HighBits)
 	}

--- a/simd/ascii.go
+++ b/simd/ascii.go
@@ -13,9 +13,9 @@ import (
 // IsASCII reports whether every byte in data is ASCII (< 0x80). An empty
 // slice is trivially ASCII.
 //
-// On amd64 with AVX2 and inputs of MinLen+ bytes it checks 32 bytes per
-// iteration with a single VPMOVMSKB; elsewhere it uses a SWAR loop over
-// 8-byte words.
+// On amd64 with AVX2 and inputs of MinLen+ bytes it ORs four 32-byte
+// vectors and tests all 128 bytes with a single VPMOVMSKB; elsewhere it
+// uses a SWAR loop over 8-byte words.
 func IsASCII(data []byte) bool {
 	if len(data) == 0 {
 		return true
@@ -24,9 +24,78 @@ func IsASCII(data []byte) bool {
 }
 
 // FirstNonASCII returns the index of the first byte >= 0x80 in data, or -1
-// if data is all ASCII. Use it to find where UTF-8 sequences begin. It scans
-// with SWAR words (no AVX2 kernel).
+// if data is all ASCII. Use it to find where UTF-8 sequences begin.
+//
+// It reads the same signal as IsASCII — a non-ASCII byte is exactly a byte
+// with its high bit set — so on amd64 with AVX2 and inputs of MinLen+
+// bytes it also tests 128 bytes per VPMOVMSKB, keeping the four vectors
+// live so the hit path can pinpoint the byte; elsewhere it falls back to
+// SWAR words.
 func FirstNonASCII(data []byte) int {
+	if len(data) == 0 {
+		return -1
+	}
+	return firstNonASCIIImpl(data)
+}
+
+// CountNonASCII returns the number of bytes >= 0x80 in data.
+//
+// On amd64 with AVX2 and inputs of MinLen+ bytes it turns each 32-byte
+// vector into a high-bit mask and adds its population count; elsewhere it
+// counts SWAR-word-wise with a popcount per word.
+func CountNonASCII(data []byte) int {
+	return countNonASCIIImpl(data)
+}
+
+// isASCIIGeneric is the portable SWAR implementation behind IsASCII. No
+// index is needed, so detection can be deferred: whole groups of words are
+// OR-ed into one accumulator and tested once, four words per branch and
+// then two, which is what turns the per-word test into a per-32-byte one.
+// Inputs of 8..15 bytes skip the loops entirely — two overlapping words
+// already cover them — and every 8+ byte input finishes with one
+// overlapping word at n-8.
+func isASCIIGeneric(data []byte) bool {
+	n := len(data)
+	if n < swar.WordLen {
+		for i := range n {
+			if data[i] >= 0x80 {
+				return false
+			}
+		}
+		return true
+	}
+	if n < 2*swar.WordLen {
+		return (swar.Load8(data, 0)|swar.Load8(data, n-swar.WordLen))&swar.HighBits == 0
+	}
+	i := 0
+	for ; i+4*swar.WordLen <= n; i += 4 * swar.WordLen {
+		acc := swar.Load8(data, i) |
+			swar.Load8(data, i+swar.WordLen) |
+			swar.Load8(data, i+2*swar.WordLen) |
+			swar.Load8(data, i+3*swar.WordLen)
+		if acc&swar.HighBits != 0 {
+			return false
+		}
+	}
+	for ; i+2*swar.WordLen <= n; i += 2 * swar.WordLen {
+		if (swar.Load8(data, i)|swar.Load8(data, i+swar.WordLen))&swar.HighBits != 0 {
+			return false
+		}
+	}
+	for ; i+swar.WordLen <= n; i += swar.WordLen {
+		if swar.Load8(data, i)&swar.HighBits != 0 {
+			return false
+		}
+	}
+	if i == n {
+		return true
+	}
+	return swar.Load8(data, n-swar.WordLen)&swar.HighBits == 0
+}
+
+// firstNonASCIIGeneric is the portable SWAR implementation behind
+// FirstNonASCII: two words per branch, then one overlapping word at n-8.
+func firstNonASCIIGeneric(data []byte) int {
 	n := len(data)
 	if n < swar.WordLen {
 		for i := range n {
@@ -37,6 +106,16 @@ func FirstNonASCII(data []byte) int {
 		return -1
 	}
 	i := 0
+	for ; i+2*swar.WordLen <= n; i += 2 * swar.WordLen {
+		m0 := swar.Load8(data, i) & swar.HighBits
+		m1 := swar.Load8(data, i+swar.WordLen) & swar.HighBits
+		if m0|m1 != 0 {
+			if m0 != 0 {
+				return i + swar.FirstLane(m0)
+			}
+			return i + swar.WordLen + swar.FirstLane(m1)
+		}
+	}
 	for ; i+swar.WordLen <= n; i += swar.WordLen {
 		if m := swar.Load8(data, i) & swar.HighBits; m != 0 {
 			return i + swar.FirstLane(m)
@@ -53,9 +132,12 @@ func FirstNonASCII(data []byte) int {
 	return -1
 }
 
-// CountNonASCII returns the number of bytes >= 0x80 in data. It counts
-// SWAR-word-wise with a popcount per word (no AVX2 kernel).
-func CountNonASCII(data []byte) int {
+// countNonASCIIGeneric is the portable SWAR implementation behind
+// CountNonASCII: a popcount of the 0x80 lane bits per word. Unlike the
+// first-match scans it is not unrolled — the per-word popcount already
+// keeps the pipeline busy, and splitting the sum across accumulators
+// measured slower.
+func countNonASCIIGeneric(data []byte) int {
 	count := 0
 	i := 0
 	n := len(data)
@@ -70,29 +152,4 @@ func CountNonASCII(data []byte) int {
 		}
 	}
 	return count
-}
-
-// isASCIIGeneric is the portable SWAR implementation behind IsASCII: it
-// masks each 8-byte word with the 0x80 lane bits, finishing 8+ byte inputs
-// with one overlapping word at n-8.
-func isASCIIGeneric(data []byte) bool {
-	n := len(data)
-	if n < swar.WordLen {
-		for i := range n {
-			if data[i] >= 0x80 {
-				return false
-			}
-		}
-		return true
-	}
-	i := 0
-	for ; i+swar.WordLen <= n; i += swar.WordLen {
-		if swar.Load8(data, i)&swar.HighBits != 0 {
-			return false
-		}
-	}
-	if i == n {
-		return true
-	}
-	return swar.Load8(data, n-swar.WordLen)&swar.HighBits == 0
 }

--- a/simd/ascii_amd64.go
+++ b/simd/ascii_amd64.go
@@ -6,10 +6,27 @@
 
 package simd
 
-// isASCIIAVX2 is implemented in ascii_amd64.s.
+// vectorLen is the AVX2 register width in bytes. MinLen happens to equal
+// it today, but the two mean different things — MinLen is a dispatch
+// tuning knob, vectorLen is a hardware fact — so the alignment arithmetic
+// below uses this constant rather than MinLen.
+const vectorLen = 32
+
+// The ASCII kernels are implemented in ascii_amd64.s. All three read the
+// same signal (a byte is non-ASCII exactly when its high bit is set, which
+// VPMOVMSKB gathers 32 at a time) and process four vectors per iteration.
 //
 //go:noescape
 func isASCIIAVX2(data []byte) bool
+
+//go:noescape
+func firstNonASCIIAVX2(data []byte) int
+
+// countNonASCIIAVX2 requires len(data) to be a multiple of vectorLen; see
+// countNonASCIIImpl.
+//
+//go:noescape
+func countNonASCIIAVX2(data []byte) int
 
 // isASCIIImpl dispatches to the AVX2 kernel for inputs large enough to amortize
 // the vector setup; smaller inputs and pre-AVX2 CPUs take the SWAR path.
@@ -18,4 +35,26 @@ func isASCIIImpl(data []byte) bool {
 		return isASCIIAVX2(data)
 	}
 	return isASCIIGeneric(data)
+}
+
+// firstNonASCIIImpl dispatches like isASCIIImpl.
+func firstNonASCIIImpl(data []byte) int {
+	if hasAVX2 && len(data) >= MinLen {
+		return firstNonASCIIAVX2(data)
+	}
+	return firstNonASCIIGeneric(data)
+}
+
+// countNonASCIIImpl splits the input at the last whole vector. Counting is
+// the one scan here that cannot finish with the overlapping final window
+// the first-match kernels use — rescanning bytes would double-count them —
+// so instead of paying for a masked epilogue in assembly, the kernel takes
+// the vector-aligned prefix and the SWAR loop counts the at most 31
+// remaining bytes.
+func countNonASCIIImpl(data []byte) int {
+	if hasAVX2 && len(data) >= MinLen {
+		head := len(data) &^ (vectorLen - 1)
+		return countNonASCIIAVX2(data[:head]) + countNonASCIIGeneric(data[head:])
+	}
+	return countNonASCIIGeneric(data)
 }

--- a/simd/ascii_amd64.go
+++ b/simd/ascii_amd64.go
@@ -6,15 +6,12 @@
 
 package simd
 
-// vectorLen is the AVX2 register width in bytes. MinLen happens to equal
-// it today, but the two mean different things — MinLen is a dispatch
-// tuning knob, vectorLen is a hardware fact — so the alignment arithmetic
-// below uses this constant rather than MinLen.
-const vectorLen = 32
-
 // The ASCII kernels are implemented in ascii_amd64.s. All three read the
 // same signal (a byte is non-ASCII exactly when its high bit is set, which
 // VPMOVMSKB gathers 32 at a time) and process four vectors per iteration.
+// Like the rest of the package's kernels they are self-bounding: each one
+// clamps its own vector loops and finishes short remainders itself, so
+// none of them carries a length precondition for the caller to uphold.
 //
 //go:noescape
 func isASCIIAVX2(data []byte) bool
@@ -22,9 +19,6 @@ func isASCIIAVX2(data []byte) bool
 //go:noescape
 func firstNonASCIIAVX2(data []byte) int
 
-// countNonASCIIAVX2 requires len(data) to be a multiple of vectorLen; see
-// countNonASCIIImpl.
-//
 //go:noescape
 func countNonASCIIAVX2(data []byte) int
 
@@ -45,16 +39,17 @@ func firstNonASCIIImpl(data []byte) int {
 	return firstNonASCIIGeneric(data)
 }
 
-// countNonASCIIImpl splits the input at the last whole vector. Counting is
-// the one scan here that cannot finish with the overlapping final window
-// the first-match kernels use — rescanning bytes would double-count them —
-// so instead of paying for a masked epilogue in assembly, the kernel takes
-// the vector-aligned prefix and the SWAR loop counts the at most 31
-// remaining bytes.
+// countNonASCIIImpl dispatches like isASCIIImpl, with the extra POPCNT
+// check its kernel needs. The kernel counts its own sub-vector remainder,
+// so there is no prefix/suffix split here. An earlier version did split,
+// handing the remainder to countNonASCIIGeneric, and paid a second
+// non-inlinable call even when the remainder was empty — enough to put
+// this scan behind its own SWAR fallback at MinLen (11.3ns vs 8.8ns at
+// 32B). With the split gone the two are level at 32B and the kernel pulls
+// ahead from 64B up, so MinLen stays the shared threshold.
 func countNonASCIIImpl(data []byte) int {
-	if hasAVX2 && len(data) >= MinLen {
-		head := len(data) &^ (vectorLen - 1)
-		return countNonASCIIAVX2(data[:head]) + countNonASCIIGeneric(data[head:])
+	if hasAVX2 && hasPOPCNT && len(data) >= MinLen {
+		return countNonASCIIAVX2(data)
 	}
 	return countNonASCIIGeneric(data)
 }

--- a/simd/ascii_amd64.s
+++ b/simd/ascii_amd64.s
@@ -240,10 +240,14 @@ fna_found_scalar:
 
 // func countNonASCIIAVX2(data []byte) int
 //
-// AVX2 kernel behind CountNonASCII. len(data) must be a multiple of 32:
-// counting cannot use the overlapping-window trick the first-match scans
-// rely on (it would double-count), so the Go wrapper hands the sub-vector
-// remainder to the SWAR path instead of paying for a masked epilogue here.
+// AVX2 kernel behind CountNonASCII. Counting is the one scan here that
+// cannot finish with the overlapping final window the first-match kernels
+// use — rescanning bytes would count them twice — so instead the vector
+// loops stop at the last whole vector and a branch-free byte loop takes
+// the remaining 0-31 bytes. That keeps the kernel self-bounding for any
+// length, like every other kernel in this package: it never reads past
+// data[len(data)-1], so no caller-side length preconditioning stands
+// between it and an out-of-bounds read.
 //
 // Each vector's high bits become a 32-bit mask and POPCNT turns it into a
 // lane count. Four masks are extracted before the four POPCNTs so the
@@ -251,9 +255,12 @@ fna_found_scalar:
 // writes the register its own VPMOVMSKB just produced, so the destination
 // false dependency Intel CPUs carry on POPCNT is already satisfied.
 //
+// POPCNT is a separate CPUID feature from AVX2, so countNonASCIIImpl gates
+// on both; see cpu_amd64.go.
+//
 // Parameters (FP offsets):
 //   data_base+0(FP)  - pointer to data (8 bytes)
-//   data_len+8(FP)   - data length, a multiple of 32 (8 bytes)
+//   data_len+8(FP)   - data length (8 bytes)
 //   data_cap+16(FP)  - data capacity (8 bytes, unused)
 //   ret+24(FP)       - number of bytes >= 0x80 (8 bytes)
 TEXT ·countNonASCIIAVX2(SB), NOSPLIT, $0-32
@@ -266,8 +273,12 @@ TEXT ·countNonASCIIAVX2(SB), NOSPLIT, $0-32
 	TESTQ   DX, DX
 	JZ      cna_done
 
-	LEAQ    (SI)(DX*1), R8
-	LEAQ    -128(R8), R11
+	LEAQ    (SI)(DX*1), R8          // R8 = end pointer
+	CMPQ    DX, $32
+	JB      cna_tail                // no whole vector: byte loop only
+
+	LEAQ    -32(R8), R12            // last valid 32-byte window base
+	LEAQ    -128(R8), R11           // last valid 128-byte block base
 	CMPQ    SI, R11
 	JA      cna_loop32_entry
 
@@ -294,8 +305,8 @@ cna_loop128:
 	JBE     cna_loop128
 
 cna_loop32_entry:
-	CMPQ    SI, R8
-	JAE     cna_done
+	CMPQ    SI, R12
+	JA      cna_tail
 
 cna_loop32:
 	VMOVDQU (SI), Y0
@@ -303,8 +314,19 @@ cna_loop32:
 	POPCNTL AX, AX
 	ADDQ    AX, R9
 	ADDQ    $32, SI
+	CMPQ    SI, R12
+	JBE     cna_loop32
+
+cna_tail:
+	// 0-31 bytes left. Shifting the byte down to its high bit turns the
+	// test into an add, so the loop carries no data-dependent branch.
 	CMPQ    SI, R8
-	JB      cna_loop32
+	JAE     cna_done
+	MOVBLZX (SI), AX
+	SHRL    $7, AX
+	ADDQ    AX, R9
+	INCQ    SI
+	JMP     cna_tail
 
 cna_done:
 	ADDQ    R13, R9

--- a/simd/ascii_amd64.s
+++ b/simd/ascii_amd64.s
@@ -2,30 +2,38 @@
 // (package simd), Copyright (c) 2025 Andrey Kolkov and contributors,
 // MIT License. See the LICENSE file in this directory for the full text.
 // Modified: legacy-SSE MOVD/MOVQ register moves replaced with VEX-encoded
-// VMOVD/VMOVQ to avoid AVX-SSE transition penalties on Intel CPUs, and the
+// VMOVD/VMOVQ to avoid AVX-SSE transition penalties on Intel CPUs, the
 // scalar tail loop replaced with one overlapping vector at the buffer end
-// for the MinLen+ inputs the Go dispatch guarantees.
+// for the MinLen+ inputs the Go dispatch guarantees, the 32-byte main loop
+// replaced with a 4x unrolled 128-byte block, and firstNonASCIIAVX2 /
+// countNonASCIIAVX2 added so the locating and counting scans no longer
+// have to fall back to SWAR words on amd64.
 
 //go:build amd64
 
 #include "textflag.h"
 
+// All three kernels share one observation: a byte is non-ASCII exactly when
+// its high bit is set, and VPMOVMSKB gathers those 32 high bits into a
+// scalar register in one instruction. OR-ing four vectors before the
+// extraction therefore preserves "some byte in these 128 was non-ASCII"
+// exactly, which is what lets the block loop test 128 bytes with a single
+// port-0 VPMOVMSKB. Both loops test their bound at the bottom against a
+// precomputed limit pointer.
+
 // func isASCIIAVX2(data []byte) bool
 //
 // AVX2 implementation of ASCII detection that checks if all bytes are < 0x80.
-// Processes 32 bytes per iteration using 256-bit vector operations.
 //
 // Algorithm:
-//  1. Main loop: load 32 bytes, use VPMOVMSKB to extract high bits
-//  2. If any high bit is set (mask != 0), return false (non-ASCII found)
-//  3. Handle the tail by retesting one overlapping 32-byte window ending
-//     at the buffer end (a scalar loop only for sub-32 direct calls,
-//     unreachable through the Go dispatch)
-//  4. Always call VZEROUPPER before returning (critical for performance)
-//
-// The key insight: ASCII bytes have the high bit (bit 7) clear (0x00-0x7F).
-// VPMOVMSKB extracts bit 7 from each byte into a 32-bit mask.
-// If mask == 0, all 32 bytes are ASCII.
+//  1. Block loop: OR four 32-byte vectors, extract the high bits with
+//     VPMOVMSKB, and return false if any is set. The loads fold into the
+//     VPOR operands, so a block costs four memory ops and one extraction.
+//  2. 32-byte loop for the remainder, then one overlapping 32-byte window
+//     ending at the buffer end (rescanning bytes already proven ASCII
+//     cannot change the outcome). A scalar loop serves only sub-32 direct
+//     calls, unreachable through the Go dispatch.
+//  3. Always call VZEROUPPER before returning (critical for performance)
 //
 // Parameters (FP offsets):
 //   data_base+0(FP)  - pointer to data (8 bytes)
@@ -43,46 +51,51 @@ TEXT ·isASCIIAVX2(SB), NOSPLIT, $0-25
 	TESTQ   DX, DX
 	JZ      all_ascii
 
-	// Save start pointer
-	MOVQ    SI, DI                  // DI = data start (preserved)
-
 	// Calculate end pointer
 	LEAQ    (SI)(DX*1), R8          // R8 = SI + length (end pointer)
 
-	// Main loop: process 32 bytes per iteration
-loop32:
-	// Check if we have at least 32 bytes remaining
-	LEAQ    32(SI), R9              // R9 = SI + 32
-	CMPQ    R9, R8                  // Compare with end pointer
-	JA      handle_tail             // If R9 > R8, less than 32 bytes left
-
-	// Load 32 bytes from data (unaligned load is safe and fast with AVX2)
-	VMOVDQU (SI), Y0                // Y0 = data[SI:SI+32]
-
-	// Extract high bit of each byte into 32-bit mask
-	// VPMOVMSKB: bit i in result = bit 7 of byte i in source vector
-	// If any byte >= 0x80, its high bit is 1, so mask != 0
-	VPMOVMSKB Y0, AX                // AX = 32-bit mask of high bits
-
-	// Check if any non-ASCII byte found (mask != 0)
-	TESTL   AX, AX
-	JNZ     found_non_ascii         // Non-zero mask means non-ASCII found
-
-	// All 32 bytes are ASCII, advance to next chunk
-	ADDQ    $32, SI
-	JMP     loop32
-
-handle_tail:
-	// Fewer than 32 bytes remain. If any do, retest the final 32-byte
-	// window ending at the buffer end — rescanning bytes already proven
-	// ASCII cannot change the outcome. Inputs shorter than 32 bytes
-	// (unreachable through the Go dispatch) take the scalar loop.
-	CMPQ    SI, R8
-	JAE     all_ascii               // If SI >= end, all bytes processed
 	CMPQ    DX, $32
 	JB      tail_loop               // sub-32 direct call: scalar
 
-	VMOVDQU -32(R8), Y0             // Y0 = data[len-32:len]
+	LEAQ    -32(R8), R12            // last valid 32-byte window base
+	LEAQ    -128(R8), R11           // last valid 128-byte block base
+	CMPQ    SI, R11
+	JA      loop32_entry
+
+loop128:
+	VMOVDQU (SI), Y0
+	VPOR    32(SI), Y0, Y0
+	VPOR    64(SI), Y0, Y0
+	VPOR    96(SI), Y0, Y0
+	VPMOVMSKB Y0, AX
+	TESTL   AX, AX
+	JNZ     found_non_ascii
+
+	ADDQ    $128, SI
+	CMPQ    SI, R11
+	JBE     loop128
+
+loop32_entry:
+	CMPQ    SI, R12
+	JA      last32
+
+loop32:
+	// Load 32 bytes (unaligned load is safe and fast with AVX2) and
+	// extract the high bit of each byte into a 32-bit mask.
+	VMOVDQU (SI), Y0
+	VPMOVMSKB Y0, AX
+	TESTL   AX, AX
+	JNZ     found_non_ascii
+
+	ADDQ    $32, SI
+	CMPQ    SI, R12
+	JBE     loop32
+
+last32:
+	// Fewer than 32 bytes remain past SI; retest the final window.
+	CMPQ    SI, R8
+	JAE     all_ascii
+	VMOVDQU (R12), Y0
 	VPMOVMSKB Y0, AX
 	TESTL   AX, AX
 	JNZ     found_non_ascii
@@ -92,7 +105,7 @@ tail_loop:
 	// Load one byte and check high bit
 	MOVBLZX (SI), AX                // AX = data[SI] (zero-extended)
 	TESTB   $0x80, AL               // Check if high bit is set
-	JNZ     found_non_ascii_scalar  // If set, non-ASCII found
+	JNZ     found_non_ascii         // If set, non-ASCII found
 
 	// Advance to next byte
 	INCQ    SI
@@ -106,13 +119,195 @@ all_ascii:
 	RET
 
 found_non_ascii:
-	// Non-ASCII byte found in vector
 	MOVB    $0, ret+24(FP)          // Return false
 	VZEROUPPER                      // Clear upper YMM bits
 	RET
 
-found_non_ascii_scalar:
-	// Non-ASCII byte found in scalar loop
-	MOVB    $0, ret+24(FP)          // Return false
-	VZEROUPPER                      // Clear upper YMM bits
+// func firstNonASCIIAVX2(data []byte) int
+//
+// AVX2 kernel behind FirstNonASCII: the same scan as isASCIIAVX2, but the
+// block loop keeps the four source vectors live so the hit path can
+// re-extract them in address order and BSF the first non-ASCII byte.
+//
+// Parameters (FP offsets):
+//   data_base+0(FP)  - pointer to data (8 bytes)
+//   data_len+8(FP)   - data length (8 bytes)
+//   data_cap+16(FP)  - data capacity (8 bytes, unused)
+//   ret+24(FP)       - return value: index or -1 (8 bytes)
+TEXT ·firstNonASCIIAVX2(SB), NOSPLIT, $0-32
+	MOVQ    data_base+0(FP), SI
+	MOVQ    data_len+8(FP), DX
+
+	TESTQ   DX, DX
+	JZ      fna_not_found
+
+	MOVQ    SI, DI                  // DI = data start (preserved)
+	LEAQ    (SI)(DX*1), R8
+
+	CMPQ    DX, $32
+	JB      fna_tail_loop           // sub-32 direct call: scalar
+
+	LEAQ    -32(R8), R12
+	LEAQ    -128(R8), R11
+	CMPQ    SI, R11
+	JA      fna_loop32_entry
+
+fna_loop128:
+	VMOVDQU (SI), Y0
+	VMOVDQU 32(SI), Y1
+	VMOVDQU 64(SI), Y2
+	VMOVDQU 96(SI), Y3
+	VPOR    Y0, Y1, Y4
+	VPOR    Y2, Y3, Y5
+	VPOR    Y4, Y5, Y4
+	VPMOVMSKB Y4, CX
+	TESTL   CX, CX
+	JNZ     fna_found_in_block
+
+	ADDQ    $128, SI
+	CMPQ    SI, R11
+	JBE     fna_loop128
+
+fna_loop32_entry:
+	CMPQ    SI, R12
+	JA      fna_last32
+
+fna_loop32:
+	VMOVDQU (SI), Y0
+	VPMOVMSKB Y0, CX
+	TESTL   CX, CX
+	JNZ     fna_found_in_vector
+
+	ADDQ    $32, SI
+	CMPQ    SI, R12
+	JBE     fna_loop32
+
+fna_last32:
+	// Fewer than 32 bytes remain past SI; rescan the final window. Lanes
+	// before SI are known ASCII, so the first set lane falls in the new
+	// bytes.
+	CMPQ    SI, R8
+	JAE     fna_not_found
+	MOVQ    R12, SI
+	VMOVDQU (SI), Y0
+	VPMOVMSKB Y0, CX
+	TESTL   CX, CX
+	JNZ     fna_found_in_vector
+	JMP     fna_not_found
+
+fna_tail_loop:
+	MOVBLZX (SI), AX
+	TESTB   $0x80, AL
+	JNZ     fna_found_scalar
+	INCQ    SI
+	CMPQ    SI, R8
+	JB      fna_tail_loop
+
+fna_not_found:
+	MOVQ    $-1, AX
+	MOVQ    AX, ret+24(FP)
+	VZEROUPPER
+	RET
+
+fna_found_in_block:
+	VPMOVMSKB Y0, CX
+	TESTL   CX, CX
+	JNZ     fna_found_in_vector
+	ADDQ    $32, SI
+	VPMOVMSKB Y1, CX
+	TESTL   CX, CX
+	JNZ     fna_found_in_vector
+	ADDQ    $32, SI
+	VPMOVMSKB Y2, CX
+	TESTL   CX, CX
+	JNZ     fna_found_in_vector
+	ADDQ    $32, SI
+	VPMOVMSKB Y3, CX
+
+fna_found_in_vector:
+	BSFL    CX, CX
+	SUBQ    DI, SI
+	ADDQ    SI, CX
+	MOVQ    CX, ret+24(FP)
+	VZEROUPPER
+	RET
+
+fna_found_scalar:
+	SUBQ    DI, SI
+	MOVQ    SI, ret+24(FP)
+	VZEROUPPER
+	RET
+
+// func countNonASCIIAVX2(data []byte) int
+//
+// AVX2 kernel behind CountNonASCII. len(data) must be a multiple of 32:
+// counting cannot use the overlapping-window trick the first-match scans
+// rely on (it would double-count), so the Go wrapper hands the sub-vector
+// remainder to the SWAR path instead of paying for a masked epilogue here.
+//
+// Each vector's high bits become a 32-bit mask and POPCNT turns it into a
+// lane count. Four masks are extracted before the four POPCNTs so the
+// port-0 extractions and the port-1 population counts overlap; each POPCNT
+// writes the register its own VPMOVMSKB just produced, so the destination
+// false dependency Intel CPUs carry on POPCNT is already satisfied.
+//
+// Parameters (FP offsets):
+//   data_base+0(FP)  - pointer to data (8 bytes)
+//   data_len+8(FP)   - data length, a multiple of 32 (8 bytes)
+//   data_cap+16(FP)  - data capacity (8 bytes, unused)
+//   ret+24(FP)       - number of bytes >= 0x80 (8 bytes)
+TEXT ·countNonASCIIAVX2(SB), NOSPLIT, $0-32
+	MOVQ    data_base+0(FP), SI
+	MOVQ    data_len+8(FP), DX
+
+	XORQ    R9, R9                  // R9 = running count
+	XORQ    R13, R13                // R13 = second accumulator
+
+	TESTQ   DX, DX
+	JZ      cna_done
+
+	LEAQ    (SI)(DX*1), R8
+	LEAQ    -128(R8), R11
+	CMPQ    SI, R11
+	JA      cna_loop32_entry
+
+cna_loop128:
+	VMOVDQU (SI), Y0
+	VMOVDQU 32(SI), Y1
+	VMOVDQU 64(SI), Y2
+	VMOVDQU 96(SI), Y3
+	VPMOVMSKB Y0, AX
+	VPMOVMSKB Y1, BX
+	VPMOVMSKB Y2, CX
+	VPMOVMSKB Y3, R10
+	POPCNTL AX, AX
+	POPCNTL BX, BX
+	POPCNTL CX, CX
+	POPCNTL R10, R10
+	ADDQ    AX, R9
+	ADDQ    BX, R13
+	ADDQ    CX, R9
+	ADDQ    R10, R13
+
+	ADDQ    $128, SI
+	CMPQ    SI, R11
+	JBE     cna_loop128
+
+cna_loop32_entry:
+	CMPQ    SI, R8
+	JAE     cna_done
+
+cna_loop32:
+	VMOVDQU (SI), Y0
+	VPMOVMSKB Y0, AX
+	POPCNTL AX, AX
+	ADDQ    AX, R9
+	ADDQ    $32, SI
+	CMPQ    SI, R8
+	JB      cna_loop32
+
+cna_done:
+	ADDQ    R13, R9
+	MOVQ    R9, ret+24(FP)
+	VZEROUPPER
 	RET

--- a/simd/ascii_other.go
+++ b/simd/ascii_other.go
@@ -6,7 +6,16 @@
 
 package simd
 
-// isASCIIImpl uses the portable SWAR implementation off amd64.
+// The portable SWAR implementations are the only ones off amd64.
+
 func isASCIIImpl(data []byte) bool {
 	return isASCIIGeneric(data)
+}
+
+func firstNonASCIIImpl(data []byte) int {
+	return firstNonASCIIGeneric(data)
+}
+
+func countNonASCIIImpl(data []byte) int {
+	return countNonASCIIGeneric(data)
 }

--- a/simd/bench_test.go
+++ b/simd/bench_test.go
@@ -38,7 +38,7 @@ func Benchmark_Memchr2(b *testing.B) {
 				}
 			}
 		})
-		b.Run(benchName(n)+"/swar", func(b *testing.B) {
+		b.Run(benchName(n)+"/scalar", func(b *testing.B) {
 			b.ReportAllocs()
 			for range b.N {
 				if memchr2Generic(data, 'z', 'y') != -1 {
@@ -68,7 +68,7 @@ func Benchmark_Memchr3(b *testing.B) {
 				}
 			}
 		})
-		b.Run(benchName(n)+"/swar", func(b *testing.B) {
+		b.Run(benchName(n)+"/scalar", func(b *testing.B) {
 			b.ReportAllocs()
 			for range b.N {
 				if memchr3Generic(data, 'z', 'y', 'x') != -1 {

--- a/simd/bench_test.go
+++ b/simd/bench_test.go
@@ -38,6 +38,14 @@ func Benchmark_Memchr2(b *testing.B) {
 				}
 			}
 		})
+		b.Run(benchName(n)+"/swar", func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				if memchr2Generic(data, 'z', 'y') != -1 {
+					b.Fatal("unexpected match")
+				}
+			}
+		})
 		b.Run(benchName(n)+"/default", func(b *testing.B) {
 			b.ReportAllocs()
 			for range b.N {
@@ -56,6 +64,14 @@ func Benchmark_Memchr3(b *testing.B) {
 			b.ReportAllocs()
 			for range b.N {
 				if Memchr3(data, 'z', 'y', 'x') != -1 {
+					b.Fatal("unexpected match")
+				}
+			}
+		})
+		b.Run(benchName(n)+"/swar", func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				if memchr3Generic(data, 'z', 'y', 'x') != -1 {
 					b.Fatal("unexpected match")
 				}
 			}
@@ -108,6 +124,40 @@ func Benchmark_MemchrDigit(b *testing.B) {
 			b.ReportAllocs()
 			for range b.N {
 				if memchrDigitGeneric(data) != -1 {
+					b.Fatal("unexpected match")
+				}
+			}
+		})
+	}
+}
+
+// benchNonWordData is a repeating run of punctuation and spaces holding no
+// \w character, so MemchrWord has to scan the whole haystack. benchData
+// cannot serve here: its first byte is already a word character.
+func benchNonWordData(n int) []byte {
+	const punct = "!\"#$%&'()*+,-./:;<=>?@[\\]^`{|}~ "
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = punct[i%len(punct)]
+	}
+	return b
+}
+
+func Benchmark_MemchrWord(b *testing.B) {
+	for _, n := range benchSizes {
+		data := benchNonWordData(n)
+		b.Run(benchName(n)+"/simd", func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				if MemchrWord(data) != -1 {
+					b.Fatal("unexpected match")
+				}
+			}
+		})
+		b.Run(benchName(n)+"/scalar", func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				if memchrWordGeneric(data) != -1 {
 					b.Fatal("unexpected match")
 				}
 			}
@@ -267,6 +317,50 @@ func Benchmark_IsASCII(b *testing.B) {
 			b.ReportAllocs()
 			for range b.N {
 				if !isASCIIGeneric(data) {
+					b.Fatal("unexpected non-ASCII")
+				}
+			}
+		})
+	}
+}
+
+func Benchmark_FirstNonASCII(b *testing.B) {
+	for _, n := range benchSizes {
+		data := benchData(n)
+		b.Run(benchName(n)+"/simd", func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				if FirstNonASCII(data) != -1 {
+					b.Fatal("unexpected non-ASCII")
+				}
+			}
+		})
+		b.Run(benchName(n)+"/swar", func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				if firstNonASCIIGeneric(data) != -1 {
+					b.Fatal("unexpected non-ASCII")
+				}
+			}
+		})
+	}
+}
+
+func Benchmark_CountNonASCII(b *testing.B) {
+	for _, n := range benchSizes {
+		data := benchData(n)
+		b.Run(benchName(n)+"/simd", func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				if CountNonASCII(data) != 0 {
+					b.Fatal("unexpected non-ASCII")
+				}
+			}
+		})
+		b.Run(benchName(n)+"/swar", func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				if countNonASCIIGeneric(data) != 0 {
 					b.Fatal("unexpected non-ASCII")
 				}
 			}

--- a/simd/cpu_amd64.go
+++ b/simd/cpu_amd64.go
@@ -11,3 +11,12 @@ import (
 // register state, and the value is read once at init so the per-call
 // dispatch is a single predictable branch.
 var hasAVX2 = cpu.X86.HasAVX2
+
+// hasPOPCNT gates countNonASCIIAVX2, the one kernel that reaches outside
+// the AVX/AVX2 instruction set: it turns each vector's high-bit mask into
+// a lane count with POPCNT, whose CPUID bit (01H:ECX[23]) is independent
+// of AVX2's. Every shipping AVX2 part has POPCNT, but a hypervisor can
+// mask the two separately, and an ungated POPCNT would be SIGILL rather
+// than a fallback — so the count dispatch checks both and drops to the
+// SWAR path if either is missing.
+var hasPOPCNT = cpu.X86.HasPOPCNT

--- a/simd/fuzz_test.go
+++ b/simd/fuzz_test.go
@@ -116,9 +116,68 @@ func FuzzIsASCII(f *testing.F) {
 		if got := isASCIIGeneric(h); got != want {
 			t.Fatalf("isASCIIGeneric(%q) = %v, want %v", h, got, want)
 		}
-		first := FirstNonASCII(h)
-		if want != (first == -1) {
-			t.Fatalf("FirstNonASCII(%q) = %d inconsistent with IsASCII = %v", h, first, want)
+		// Check the index itself, not just its sign: the AVX2 kernel
+		// locates the byte by re-extracting four per-vector masks in
+		// address order, so a transposed arm returns a wrong-but-positive
+		// index that a consistency check with IsASCII cannot see.
+		wantFirst := refFirstNonASCII(h)
+		if got := FirstNonASCII(h); got != wantFirst {
+			t.Fatalf("FirstNonASCII(%q) = %d, want %d", h, got, wantFirst)
+		}
+		if got := firstNonASCIIGeneric(h); got != wantFirst {
+			t.Fatalf("firstNonASCIIGeneric(%q) = %d, want %d", h, got, wantFirst)
+		}
+		wantCount := refCountNonASCII(h)
+		if got := CountNonASCII(h); got != wantCount {
+			t.Fatalf("CountNonASCII(%q) = %d, want %d", h, got, wantCount)
+		}
+		if got := countNonASCIIGeneric(h); got != wantCount {
+			t.Fatalf("countNonASCIIGeneric(%q) = %d, want %d", h, got, wantCount)
+		}
+	})
+}
+
+// FuzzMemchrClass covers the \w classifier, which the AVX2 kernels compute
+// from a hand-built pair of VPSHUFB nibble tables and the fallbacks from
+// SWAR range masks — two independent derivations of one character class,
+// so a table nibble that is wrong for some byte value shows up here.
+func FuzzMemchrClass(f *testing.F) {
+	f.Add([]byte("hello world"))
+	f.Add([]byte("________"))
+	f.Add([]byte("!\"#$%&'()*+,-./:;<=>?@[\\]^`{|}~ "))
+	f.Add(append(bytes.Repeat([]byte{'a'}, 63), '.'))
+	f.Add(append(bytes.Repeat([]byte{'.'}, 129), '_'))
+	f.Add([]byte{0x2f, 0x30, 0x39, 0x3a, 0x40, 0x41, 0x5a, 0x5b, 0x5e, 0x5f, 0x60, 0x7a, 0x7b, 0x7f, 0x80, 0xff})
+	f.Fuzz(func(t *testing.T, h []byte) {
+		wantWord, wantNot, wantDigit := -1, -1, -1
+		for i, b := range h {
+			if wantWord < 0 && refIsWord(b) {
+				wantWord = i
+			}
+			if wantNot < 0 && !refIsWord(b) {
+				wantNot = i
+			}
+			if wantDigit < 0 && b >= '0' && b <= '9' {
+				wantDigit = i
+			}
+		}
+		if got := MemchrWord(h); got != wantWord {
+			t.Fatalf("MemchrWord(%q) = %d, want %d", h, got, wantWord)
+		}
+		if got := memchrWordGeneric(h); got != wantWord {
+			t.Fatalf("memchrWordGeneric(%q) = %d, want %d", h, got, wantWord)
+		}
+		if got := MemchrNotWord(h); got != wantNot {
+			t.Fatalf("MemchrNotWord(%q) = %d, want %d", h, got, wantNot)
+		}
+		if got := memchrNotWordGeneric(h); got != wantNot {
+			t.Fatalf("memchrNotWordGeneric(%q) = %d, want %d", h, got, wantNot)
+		}
+		if got := MemchrDigit(h); got != wantDigit {
+			t.Fatalf("MemchrDigit(%q) = %d, want %d", h, got, wantDigit)
+		}
+		if got := memchrDigitGeneric(h); got != wantDigit {
+			t.Fatalf("memchrDigitGeneric(%q) = %d, want %d", h, got, wantDigit)
 		}
 	})
 }

--- a/simd/guard_amd64_test.go
+++ b/simd/guard_amd64_test.go
@@ -1,0 +1,108 @@
+//go:build amd64 && linux
+
+package simd
+
+import (
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Every kernel in this package is self-bounding: it clamps its own vector
+// loops and finishes short remainders itself, so it may be called directly
+// with any length. That is not testable with ordinary slices — Go rounds
+// allocations up to a size class, so a read past the end lands on
+// zero-filled slack and the wrong answer never materializes. These tests
+// place the last byte of the input flush against an unmapped page, turning
+// any over-read into a fault instead of a silent success.
+//
+// countNonASCIIAVX2 is the reason this file exists: it is the one kernel
+// whose result depends on the trailing bytes, so it cannot use the
+// overlapping-window epilogue its siblings use, and an earlier version
+// looped while base < end and read whole vectors past the slice.
+
+// guardedTail returns a slice of n bytes whose final byte is the last
+// readable byte before an unmapped page, plus a cleanup function. Reading
+// even one byte past the end faults.
+func guardedTail(t *testing.T, n int) []byte {
+	t.Helper()
+	pageSize := syscall.Getpagesize()
+	require.LessOrEqual(t, n, pageSize, "input must fit in one page")
+
+	// Two pages, then drop read access to the second one.
+	region, err := syscall.Mmap(-1, 0, 2*pageSize,
+		syscall.PROT_READ|syscall.PROT_WRITE,
+		syscall.MAP_PRIVATE|syscall.MAP_ANON)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, syscall.Munmap(region))
+	})
+	require.NoError(t, syscall.Mprotect(region[pageSize:], syscall.PROT_NONE))
+
+	return region[pageSize-n : pageSize : pageSize]
+}
+
+func Test_KernelsAreSelfBounding(t *testing.T) {
+	if !Accelerated() {
+		t.Skip("AVX2 kernels not active on this CPU")
+	}
+	// Lengths that leave every possible sub-vector and sub-block
+	// remainder, including the 1..31 that has no whole vector at all.
+	for _, n := range []int{
+		1, 2, 7, 8, 15, 16, 31, 32, 33, 63, 64, 65, 95,
+		96, 127, 128, 129, 159, 160, 161, 200, 255, 256, 257, 384, 385,
+	} {
+		buf := guardedTail(t, n)
+		for i := range buf {
+			buf[i] = byte('a' + i%23)
+		}
+		// Each kernel is called directly, bypassing the *Impl dispatch, so
+		// the guard is on the kernel itself and not on a wrapper.
+		require.True(t, isASCIIAVX2(buf), "isASCIIAVX2 len %d", n)
+		require.Equal(t, -1, firstNonASCIIAVX2(buf), "firstNonASCIIAVX2 len %d", n)
+		if hasPOPCNT {
+			require.Equal(t, 0, countNonASCIIAVX2(buf), "countNonASCIIAVX2 len %d", n)
+		}
+		require.Equal(t, -1, memchr2AVX2(buf, 'z', 'y'), "memchr2AVX2 len %d", n)
+		require.Equal(t, -1, memchr3AVX2(buf, 'z', 'y', 'x'), "memchr3AVX2 len %d", n)
+		require.Equal(t, -1, memchrDigitAVX2(buf), "memchrDigitAVX2 len %d", n)
+		require.Equal(t, -1, memchrNotWordAVX2(buf), "memchrNotWordAVX2 len %d", n)
+		for _, offset := range []int{1, 2, 8, 31, 32, 33} {
+			if offset >= n {
+				continue
+			}
+			require.Equal(t, -1, memchrPairAVX2(buf, 'z', 'y', offset),
+				"memchrPairAVX2 len %d offset %d", n, offset)
+		}
+
+		// The word scan needs a haystack with no word characters, so it
+		// too has to walk to the end.
+		for i := range buf {
+			buf[i] = '.'
+		}
+		require.Equal(t, -1, memchrWordAVX2(buf), "memchrWordAVX2 len %d", n)
+	}
+}
+
+// Test_CountNonASCIIAVX2_CountsExactly pins the counting kernel's tail
+// handling: an over-read that happened to land on non-ASCII bytes would
+// inflate the count rather than fault, which the guard test alone cannot
+// distinguish from a correct scan of zero-filled slack.
+func Test_CountNonASCIIAVX2_CountsExactly(t *testing.T) {
+	if !Accelerated() || !hasPOPCNT {
+		t.Skip("AVX2+POPCNT kernels not active on this CPU")
+	}
+	for n := range 400 {
+		buf := guardedTail(t, max(n, 1))[:n]
+		want := 0
+		for i := range buf {
+			buf[i] = byte(i * 7)
+			if buf[i] >= 0x80 {
+				want++
+			}
+		}
+		require.Equal(t, want, countNonASCIIAVX2(buf), "len %d", n)
+		require.Equal(t, want, CountNonASCII(buf), "dispatched, len %d", n)
+	}
+}

--- a/simd/memchr.go
+++ b/simd/memchr.go
@@ -79,6 +79,20 @@ func memchr2Generic(haystack []byte, needle1, needle2 byte) int {
 	bc1 := swar.Broadcast(needle1)
 	bc2 := swar.Broadcast(needle2)
 	i := 0
+	for ; i+2*swar.WordLen <= n; i += 2 * swar.WordLen {
+		// Pinned window: see the note above isASCIIGeneric in ascii.go for
+		// why the loads use constant offsets into it.
+		win := haystack[i : i+2*swar.WordLen : i+2*swar.WordLen]
+		w0, w1 := swar.Load8(win, 0), swar.Load8(win, swar.WordLen)
+		m0 := swar.ZeroLanes(w0^bc1) | swar.ZeroLanes(w0^bc2)
+		m1 := swar.ZeroLanes(w1^bc1) | swar.ZeroLanes(w1^bc2)
+		if m0|m1 != 0 {
+			if m0 != 0 {
+				return i + swar.FirstLane(m0)
+			}
+			return i + swar.WordLen + swar.FirstLane(m1)
+		}
+	}
 	for ; i+swar.WordLen <= n; i += swar.WordLen {
 		w := swar.Load8(haystack, i)
 		if m := swar.ZeroLanes(w^bc1) | swar.ZeroLanes(w^bc2); m != 0 {
@@ -112,6 +126,18 @@ func memchr3Generic(haystack []byte, needle1, needle2, needle3 byte) int {
 	bc2 := swar.Broadcast(needle2)
 	bc3 := swar.Broadcast(needle3)
 	i := 0
+	for ; i+2*swar.WordLen <= n; i += 2 * swar.WordLen {
+		win := haystack[i : i+2*swar.WordLen : i+2*swar.WordLen]
+		w0, w1 := swar.Load8(win, 0), swar.Load8(win, swar.WordLen)
+		m0 := swar.ZeroLanes(w0^bc1) | swar.ZeroLanes(w0^bc2) | swar.ZeroLanes(w0^bc3)
+		m1 := swar.ZeroLanes(w1^bc1) | swar.ZeroLanes(w1^bc2) | swar.ZeroLanes(w1^bc3)
+		if m0|m1 != 0 {
+			if m0 != 0 {
+				return i + swar.FirstLane(m0)
+			}
+			return i + swar.WordLen + swar.FirstLane(m1)
+		}
+	}
 	for ; i+swar.WordLen <= n; i += swar.WordLen {
 		w := swar.Load8(haystack, i)
 		if m := swar.ZeroLanes(w^bc1) | swar.ZeroLanes(w^bc2) | swar.ZeroLanes(w^bc3); m != 0 {

--- a/simd/memchr_amd64.go
+++ b/simd/memchr_amd64.go
@@ -6,12 +6,14 @@
 
 package simd
 
-// Assembly kernels implemented in memchr_amd64.s. Each processes 32 bytes
-// per iteration with AVX2 and finishes the last 1-31 positions with an
-// overlapping rescan: memchr2 and memchr3 reload one 32-byte vector
-// ending at the buffer end, while memchrPair reloads both of its windows
-// — the byte1 side ending at len-offset, the byte2 side at the buffer
-// end.
+// Assembly kernels implemented in memchr_amd64.s. Each consumes four
+// 32-byte AVX2 vectors per iteration (OR-ing the per-vector match masks so
+// a 128-byte block needs one extraction and one branch), drops to a
+// 32-byte loop for the remainder, and finishes the last 1-31 positions
+// with an overlapping rescan: memchr2 and memchr3 reload one 32-byte
+// vector ending at the buffer end, while memchrPair reloads both of its
+// windows — the byte1 side ending at len-offset, the byte2 side at the
+// buffer end.
 //
 //go:noescape
 func memchr2AVX2(haystack []byte, needle1, needle2 byte) int

--- a/simd/memchr_amd64.s
+++ b/simd/memchr_amd64.s
@@ -2,25 +2,43 @@
 // (package simd), Copyright (c) 2025 Andrey Kolkov and contributors,
 // MIT License. See the LICENSE file in this directory for the full text.
 // Modified: legacy-SSE MOVD/MOVQ register moves replaced with VEX-encoded
-// VMOVD/VMOVQ to avoid AVX-SSE transition penalties on Intel CPUs, and the
+// VMOVD/VMOVQ to avoid AVX-SSE transition penalties on Intel CPUs, the
 // scalar tail loops replaced with overlapping vector rescans of the final
 // window (a vector pair in memchrPairAVX2) for the MinLen+ inputs the Go
-// dispatch guarantees.
+// dispatch guarantees, and the 32-byte main loops replaced with 4x
+// unrolled 128-byte blocks that OR the per-vector masks together and
+// extract a single VPMOVMSKB per block.
 
 //go:build amd64
 
 #include "textflag.h"
 
+// The kernels below share one loop skeleton:
+//
+//   1. A 128-byte block loop, entered only while base <= end-128. Four
+//      vectors are compared in parallel, their match masks OR-ed together,
+//      and a single VPMOVMSKB tests all 128 bytes at once. The per-vector
+//      masks stay live, so the (rare) hit path re-extracts them in address
+//      order to locate the first match. This keeps the port-0-only
+//      VPMOVMSKB and the loop bookkeeping off the critical path: the block
+//      loop retires four 32-byte compares for the branch overhead of one.
+//   2. A 32-byte loop for the remainder, entered while base <= end-32.
+//   3. One overlapping 32-byte window ending at the buffer end for the
+//      last 1-31 bytes. Lanes before the current base were already
+//      resolved as non-matching, so the first set lane of the overlap
+//      always falls in the new bytes and BSF stays exact.
+//
+// Both loops test their bound at the bottom against a precomputed limit
+// pointer, so the steady state costs one ADDQ/CMPQ/JBE instead of the
+// LEAQ/CMPQ/JA/ADDQ/JMP the original 32-byte loops carried. Inputs shorter
+// than one vector — unreachable through the Go dispatch, which routes them
+// to the SWAR fallbacks — take the scalar tail loops.
+
 // func memchr2AVX2(haystack []byte, needle1, needle2 byte) int
 //
 // AVX2 kernel behind Memchr2 that searches for either of two bytes.
 // Uses parallel comparison with two broadcast vectors and combines results
-// with VPOR. The final 1-31 bytes are handled with one overlapping 32-byte
-// vector at the buffer end: lanes before it were already resolved as
-// non-matching, so the first set lane of the overlap falls in the new bytes
-// (the same argument the SWAR fallbacks use for their overlapping word at
-// n-8). Inputs shorter than 32 bytes — unreachable through the Go dispatch,
-// which routes them to the SWAR fallback — take a scalar loop instead.
+// with VPOR.
 //
 // Parameters (FP offsets, ABI0; the byte arguments are packed into
 // adjacent 1-byte slots after the 24-byte slice header, then padded to
@@ -50,45 +68,70 @@ TEXT ·memchr2AVX2(SB), NOSPLIT, $0-40
 	VMOVD   BX, X1
 	VPBROADCASTB X1, Y1                  // Y1 = [needle2 × 32]
 
-	// Save start pointer
+	// Save start pointer and compute the end
 	MOVQ    SI, DI
-
-	// Calculate end
 	LEAQ    (SI)(DX*1), R8
 
-loop32_2:
-	LEAQ    32(SI), R9
-	CMPQ    R9, R8
-	JA      handle_tail2
+	CMPQ    DX, $32
+	JB      tail_loop2                   // sub-32 direct call: scalar
 
-	// Load chunk
+	LEAQ    -32(R8), R12                 // last valid 32-byte window base
+	LEAQ    -128(R8), R11                // last valid 128-byte block base
+	CMPQ    SI, R11
+	JA      loop32_2_entry
+
+loop128_2:
 	VMOVDQU (SI), Y2
+	VMOVDQU 32(SI), Y3
+	VMOVDQU 64(SI), Y4
+	VMOVDQU 96(SI), Y5
 
-	// Compare with both needles
-	VPCMPEQB Y0, Y2, Y3                  // Y3 = matches with needle1
-	VPCMPEQB Y1, Y2, Y4                  // Y4 = matches with needle2
+	VPCMPEQB Y0, Y2, Y6
+	VPCMPEQB Y1, Y2, Y7
+	VPOR    Y6, Y7, Y2                   // Y2 = matches in bytes 0-31
+	VPCMPEQB Y0, Y3, Y6
+	VPCMPEQB Y1, Y3, Y7
+	VPOR    Y6, Y7, Y3                   // Y3 = matches in bytes 32-63
+	VPCMPEQB Y0, Y4, Y6
+	VPCMPEQB Y1, Y4, Y7
+	VPOR    Y6, Y7, Y4                   // Y4 = matches in bytes 64-95
+	VPCMPEQB Y0, Y5, Y6
+	VPCMPEQB Y1, Y5, Y7
+	VPOR    Y6, Y7, Y5                   // Y5 = matches in bytes 96-127
 
-	// Combine results with OR (match if either needle found)
-	VPOR    Y3, Y4, Y3                   // Y3 = needle1_matches | needle2_matches
+	VPOR    Y2, Y3, Y6
+	VPOR    Y4, Y5, Y7
+	VPOR    Y6, Y7, Y6                   // Y6 = matches anywhere in the block
+	VPMOVMSKB Y6, CX
+	TESTL   CX, CX
+	JNZ     found_in_block2
 
-	// Extract mask
+	ADDQ    $128, SI
+	CMPQ    SI, R11
+	JBE     loop128_2
+
+loop32_2_entry:
+	CMPQ    SI, R12
+	JA      last32_2
+
+loop32_2:
+	VMOVDQU (SI), Y2
+	VPCMPEQB Y0, Y2, Y3
+	VPCMPEQB Y1, Y2, Y4
+	VPOR    Y3, Y4, Y3
 	VPMOVMSKB Y3, CX
 	TESTL   CX, CX
 	JNZ     found_in_vector2
 
 	ADDQ    $32, SI
-	JMP     loop32_2
+	CMPQ    SI, R12
+	JBE     loop32_2
 
-handle_tail2:
-	// Fewer than 32 bytes remain.
+last32_2:
+	// Fewer than 32 bytes remain past SI; rescan the final window.
 	CMPQ    SI, R8
 	JAE     not_found2
-	CMPQ    DX, $32
-	JB      tail_loop2                   // sub-32 direct call: scalar
-
-	// Rescan the final 32-byte window ending at the buffer end; lanes
-	// before SI are known non-matching, so BSF stays exact.
-	LEAQ    -32(R8), SI
+	MOVQ    R12, SI
 	VMOVDQU (SI), Y2
 	VPCMPEQB Y0, Y2, Y3
 	VPCMPEQB Y1, Y2, Y4
@@ -115,6 +158,23 @@ not_found2:
 	VZEROUPPER
 	RET
 
+found_in_block2:
+	// Locate the first hit by re-extracting the per-vector masks in
+	// address order; only one of the four can hold the lowest match.
+	VPMOVMSKB Y2, CX
+	TESTL   CX, CX
+	JNZ     found_in_vector2
+	ADDQ    $32, SI
+	VPMOVMSKB Y3, CX
+	TESTL   CX, CX
+	JNZ     found_in_vector2
+	ADDQ    $32, SI
+	VPMOVMSKB Y4, CX
+	TESTL   CX, CX
+	JNZ     found_in_vector2
+	ADDQ    $32, SI
+	VPMOVMSKB Y5, CX
+
 found_in_vector2:
 	BSFL    CX, CX
 	SUBQ    DI, SI
@@ -131,9 +191,8 @@ found_scalar2:
 
 // func memchr3AVX2(haystack []byte, needle1, needle2, needle3 byte) int
 //
-// AVX2 kernel behind Memchr3 that searches for any of three bytes.
-// Same structure as memchr2AVX2 (including the overlapping vector tail),
-// with a third broadcast/compare.
+// AVX2 kernel behind Memchr3 that searches for any of three bytes. Same
+// skeleton as memchr2AVX2 with a third broadcast/compare.
 //
 // Parameters (FP offsets, ABI0; byte arguments packed into adjacent 1-byte
 // slots after the slice header, then padded):
@@ -166,45 +225,79 @@ TEXT ·memchr3AVX2(SB), NOSPLIT, $0-40
 	VMOVD   R10, X2
 	VPBROADCASTB X2, Y2                  // Y2 = [needle3 × 32]
 
-	// Save start pointer
+	// Save start pointer and compute the end
 	MOVQ    SI, DI
-
-	// Calculate end
 	LEAQ    (SI)(DX*1), R8
 
-loop32_3:
-	LEAQ    32(SI), R9
-	CMPQ    R9, R8
-	JA      handle_tail3
+	CMPQ    DX, $32
+	JB      tail_loop3                   // sub-32 direct call: scalar
 
-	// Load chunk
+	LEAQ    -32(R8), R12                 // last valid 32-byte window base
+	LEAQ    -128(R8), R11                // last valid 128-byte block base
+	CMPQ    SI, R11
+	JA      loop32_3_entry
+
+loop128_3:
 	VMOVDQU (SI), Y3
+	VMOVDQU 32(SI), Y4
+	VMOVDQU 64(SI), Y5
+	VMOVDQU 96(SI), Y6
 
-	// Compare with all three needles
-	VPCMPEQB Y0, Y3, Y4                  // Y4 = matches with needle1
-	VPCMPEQB Y1, Y3, Y5                  // Y5 = matches with needle2
-	VPCMPEQB Y2, Y3, Y6                  // Y6 = matches with needle3
+	VPCMPEQB Y0, Y3, Y7
+	VPCMPEQB Y1, Y3, Y8
+	VPCMPEQB Y2, Y3, Y9
+	VPOR    Y7, Y8, Y7
+	VPOR    Y7, Y9, Y3                   // Y3 = matches in bytes 0-31
+	VPCMPEQB Y0, Y4, Y7
+	VPCMPEQB Y1, Y4, Y8
+	VPCMPEQB Y2, Y4, Y9
+	VPOR    Y7, Y8, Y7
+	VPOR    Y7, Y9, Y4                   // Y4 = matches in bytes 32-63
+	VPCMPEQB Y0, Y5, Y7
+	VPCMPEQB Y1, Y5, Y8
+	VPCMPEQB Y2, Y5, Y9
+	VPOR    Y7, Y8, Y7
+	VPOR    Y7, Y9, Y5                   // Y5 = matches in bytes 64-95
+	VPCMPEQB Y0, Y6, Y7
+	VPCMPEQB Y1, Y6, Y8
+	VPCMPEQB Y2, Y6, Y9
+	VPOR    Y7, Y8, Y7
+	VPOR    Y7, Y9, Y6                   // Y6 = matches in bytes 96-127
 
-	// Combine results: match if any needle found
-	VPOR    Y4, Y5, Y4                   // Y4 = needle1 | needle2
-	VPOR    Y4, Y6, Y4                   // Y4 = (needle1 | needle2) | needle3
+	VPOR    Y3, Y4, Y7
+	VPOR    Y5, Y6, Y8
+	VPOR    Y7, Y8, Y7                   // Y7 = matches anywhere in the block
+	VPMOVMSKB Y7, CX
+	TESTL   CX, CX
+	JNZ     found_in_block3
 
-	// Extract mask
+	ADDQ    $128, SI
+	CMPQ    SI, R11
+	JBE     loop128_3
+
+loop32_3_entry:
+	CMPQ    SI, R12
+	JA      last32_3
+
+loop32_3:
+	VMOVDQU (SI), Y3
+	VPCMPEQB Y0, Y3, Y4
+	VPCMPEQB Y1, Y3, Y5
+	VPCMPEQB Y2, Y3, Y6
+	VPOR    Y4, Y5, Y4
+	VPOR    Y4, Y6, Y4
 	VPMOVMSKB Y4, CX
 	TESTL   CX, CX
 	JNZ     found_in_vector3
 
 	ADDQ    $32, SI
-	JMP     loop32_3
+	CMPQ    SI, R12
+	JBE     loop32_3
 
-handle_tail3:
-	// Fewer than 32 bytes remain; overlapping vector tail, see memchr2AVX2.
+last32_3:
 	CMPQ    SI, R8
 	JAE     not_found3
-	CMPQ    DX, $32
-	JB      tail_loop3                   // sub-32 direct call: scalar
-
-	LEAQ    -32(R8), SI
+	MOVQ    R12, SI
 	VMOVDQU (SI), Y3
 	VPCMPEQB Y0, Y3, Y4
 	VPCMPEQB Y1, Y3, Y5
@@ -235,6 +328,21 @@ not_found3:
 	VZEROUPPER
 	RET
 
+found_in_block3:
+	VPMOVMSKB Y3, CX
+	TESTL   CX, CX
+	JNZ     found_in_vector3
+	ADDQ    $32, SI
+	VPMOVMSKB Y4, CX
+	TESTL   CX, CX
+	JNZ     found_in_vector3
+	ADDQ    $32, SI
+	VPMOVMSKB Y5, CX
+	TESTL   CX, CX
+	JNZ     found_in_vector3
+	ADDQ    $32, SI
+	VPMOVMSKB Y6, CX
+
 found_in_vector3:
 	BSFL    CX, CX
 	SUBQ    DI, SI
@@ -261,7 +369,8 @@ found_scalar3:
 //     - Load haystack[p+offset:p+offset+32], compare with byte2 → mask2
 //     - AND mask1, mask2 → combined mask (both bytes at correct distance)
 //  3. First set bit in combined mask is the answer
-//  4. The final 1-31 pair positions are rescanned with one overlapping
+//  4. The block loop runs the same AND over four chunk pairs at a time.
+//  5. The final 1-31 pair positions are rescanned with one overlapping
 //     vector pair whose second load ends exactly at the buffer end; pair
 //     positions before it are known non-matching, so BSF stays exact.
 //     Inputs with fewer than offset+32 bytes — unreachable through the Go
@@ -306,57 +415,86 @@ TEXT ·memchrPairAVX2(SB), NOSPLIT, $0-48
 	// - We need 32 bytes at position p+offset (for byte2 check)
 	// - So we need p + offset + 32 <= length
 	// - Which means p <= length - offset - 32
-	MOVQ    DX, R8                       // R8 = length
-	SUBQ    R10, R8                      // R8 = length - offset
-	SUBQ    $32, R8                      // R8 = length - offset - 32 (last valid p)
-	CMPQ    R8, $0
+	MOVQ    DX, R12                      // R12 = length
+	SUBQ    R10, R12                     // R12 = length - offset
+	SUBQ    $32, R12                     // R12 = length - offset - 32 (last valid p)
 	JL      scalar_entry_pair            // sub-(offset+32) direct call: scalar
+	ADDQ    SI, R12                      // R12 = absolute last valid base
 
-	// R8 now contains the last valid position for the vector loop
-	ADDQ    SI, R8                       // R8 = absolute last valid base
+	LEAQ    -96(R12), R11                // last valid 128-position block base
+	CMPQ    SI, R11
+	JA      loop32_pair_entry
 
-loop32_pair:
-	// Check if SI <= R8 (still have room for a full vector)
-	CMPQ    SI, R8
+loop128_pair:
+	// byte1 side: four consecutive 32-byte chunks
+	VMOVDQU (SI), Y2
+	VMOVDQU 32(SI), Y3
+	VMOVDQU 64(SI), Y4
+	VMOVDQU 96(SI), Y5
+	VPCMPEQB Y0, Y2, Y2
+	VPCMPEQB Y0, Y3, Y3
+	VPCMPEQB Y0, Y4, Y4
+	VPCMPEQB Y0, Y5, Y5
+
+	// byte2 side: the same chunks shifted by offset
+	VMOVDQU (SI)(R10*1), Y6
+	VMOVDQU 32(SI)(R10*1), Y7
+	VMOVDQU 64(SI)(R10*1), Y8
+	VMOVDQU 96(SI)(R10*1), Y9
+	VPCMPEQB Y1, Y6, Y6
+	VPCMPEQB Y1, Y7, Y7
+	VPCMPEQB Y1, Y8, Y8
+	VPCMPEQB Y1, Y9, Y9
+
+	VPAND   Y2, Y6, Y2                   // Y2 = pairs in positions 0-31
+	VPAND   Y3, Y7, Y3                   // Y3 = pairs in positions 32-63
+	VPAND   Y4, Y8, Y4                   // Y4 = pairs in positions 64-95
+	VPAND   Y5, Y9, Y5                   // Y5 = pairs in positions 96-127
+
+	VPOR    Y2, Y3, Y6
+	VPOR    Y4, Y5, Y7
+	VPOR    Y6, Y7, Y6
+	VPMOVMSKB Y6, CX
+	TESTL   CX, CX
+	JNZ     found_in_block_pair
+
+	ADDQ    $128, SI
+	CMPQ    SI, R11
+	JBE     loop128_pair
+
+loop32_pair_entry:
+	CMPQ    SI, R12
 	JA      vector_tail_pair
 
-	// Load 32 bytes at position p (for byte1)
+loop32_pair:
+	// Load 32 bytes at position p (for byte1) and at p+offset (for byte2)
 	VMOVDQU (SI), Y2                     // Y2 = haystack[p:p+32]
-
-	// Load 32 bytes at position p+offset (for byte2)
 	VMOVDQU (SI)(R10*1), Y3              // Y3 = haystack[p+offset:p+offset+32]
-
-	// Compare byte1
 	VPCMPEQB Y0, Y2, Y4                  // Y4 = positions where haystack[p+k] == byte1
-
-	// Compare byte2
 	VPCMPEQB Y1, Y3, Y5                  // Y5 = positions where haystack[p+offset+k] == byte2
 
 	// AND the results: bit k is set only if:
 	// - haystack[p+k] == byte1
 	// - haystack[p+offset+k] == byte2
-	// This means the pair (byte1, byte2) appears at (p+k, p+k+offset)
 	VPAND   Y4, Y5, Y4                   // Y4 = combined mask
-
-	// Extract mask
 	VPMOVMSKB Y4, CX
 	TESTL   CX, CX
 	JNZ     found_in_vector_pair
 
-	// No match in this chunk, advance by 32 bytes
 	ADDQ    $32, SI
-	JMP     loop32_pair
+	CMPQ    SI, R12
+	JBE     loop32_pair
 
 vector_tail_pair:
 	// Fewer than 32 pair positions remain past SI. If any do, rescan the
-	// final 32-position window based at R8 = base+len-offset-32: its second
+	// final 32-position window based at R12 = base+len-offset-32: its second
 	// load ends exactly at the buffer end, and pair positions before SI are
 	// known non-matching.
 	LEAQ    (DI)(DX*1), R9               // R9 = buffer end
 	SUBQ    R10, R9                      // R9 = end of valid pair positions
 	CMPQ    SI, R9
 	JAE     not_found_pair
-	MOVQ    R8, SI                       // SI = base of the final window
+	MOVQ    R12, SI                      // SI = base of the final window
 	VMOVDQU (SI), Y2
 	VMOVDQU (SI)(R10*1), Y3
 	VPCMPEQB Y0, Y2, Y4
@@ -396,6 +534,21 @@ not_found_pair:
 	MOVQ    AX, ret+40(FP)
 	VZEROUPPER
 	RET
+
+found_in_block_pair:
+	VPMOVMSKB Y2, CX
+	TESTL   CX, CX
+	JNZ     found_in_vector_pair
+	ADDQ    $32, SI
+	VPMOVMSKB Y3, CX
+	TESTL   CX, CX
+	JNZ     found_in_vector_pair
+	ADDQ    $32, SI
+	VPMOVMSKB Y4, CX
+	TESTL   CX, CX
+	JNZ     found_in_vector_pair
+	ADDQ    $32, SI
+	VPMOVMSKB Y5, CX
 
 found_in_vector_pair:
 	// Match found in vector! CX contains mask

--- a/simd/memchr_class.go
+++ b/simd/memchr_class.go
@@ -93,6 +93,19 @@ func memchrWordGeneric(haystack []byte) int {
 		return -1
 	}
 	i := 0
+	for ; i+2*swar.WordLen <= n; i += 2 * swar.WordLen {
+		// Pinned window: see the note above isASCIIGeneric in ascii.go for
+		// why the loads use constant offsets into it.
+		w := haystack[i : i+2*swar.WordLen : i+2*swar.WordLen]
+		m0 := wordMask(swar.Load8(w, 0))
+		m1 := wordMask(swar.Load8(w, swar.WordLen))
+		if m0|m1 != 0 {
+			if m0 != 0 {
+				return i + swar.FirstLane(m0)
+			}
+			return i + swar.WordLen + swar.FirstLane(m1)
+		}
+	}
 	for ; i+swar.WordLen <= n; i += swar.WordLen {
 		if m := wordMask(swar.Load8(haystack, i)); m != 0 {
 			return i + swar.FirstLane(m)
@@ -121,6 +134,17 @@ func memchrNotWordGeneric(haystack []byte) int {
 		return -1
 	}
 	i := 0
+	for ; i+2*swar.WordLen <= n; i += 2 * swar.WordLen {
+		w := haystack[i : i+2*swar.WordLen : i+2*swar.WordLen]
+		m0 := swar.HighBits &^ wordMask(swar.Load8(w, 0))
+		m1 := swar.HighBits &^ wordMask(swar.Load8(w, swar.WordLen))
+		if m0|m1 != 0 {
+			if m0 != 0 {
+				return i + swar.FirstLane(m0)
+			}
+			return i + swar.WordLen + swar.FirstLane(m1)
+		}
+	}
 	for ; i+swar.WordLen <= n; i += swar.WordLen {
 		if m := swar.HighBits &^ wordMask(swar.Load8(haystack, i)); m != 0 {
 			return i + swar.FirstLane(m)

--- a/simd/memchr_class_amd64.go
+++ b/simd/memchr_class_amd64.go
@@ -6,8 +6,10 @@
 
 package simd
 
-// Assembly kernels implemented in memchr_class_amd64.s. Range membership is
-// computed with unsigned clamp-and-compare (VPMINUB/VPMAXUB + VPCMPEQB).
+// Assembly kernels implemented in memchr_class_amd64.s. Class membership
+// is computed with a pair of VPSHUFB nibble lookups instead of one
+// clamp-and-compare per range, and four 32-byte vectors are classified per
+// iteration.
 //
 //go:noescape
 func memchrWordAVX2(haystack []byte) int

--- a/simd/memchr_class_amd64.s
+++ b/simd/memchr_class_amd64.s
@@ -2,24 +2,80 @@
 // (package simd), Copyright (c) 2025 Andrey Kolkov and contributors,
 // MIT License. See the LICENSE file in this directory for the full text.
 // Modified: legacy-SSE MOVD/MOVQ register moves replaced with VEX-encoded
-// VMOVD/VMOVQ to avoid AVX-SSE transition penalties on Intel CPUs, and the
+// VMOVD/VMOVQ to avoid AVX-SSE transition penalties on Intel CPUs, the
 // scalar tail loops replaced with one overlapping vector at the buffer end
-// for the MinLen+ inputs the Go dispatch guarantees.
+// for the MinLen+ inputs the Go dispatch guarantees, the per-range
+// clamp-and-compare classifier replaced with a nibble table lookup, and
+// the 32-byte main loops replaced with 4x unrolled 128-byte blocks.
 
 //go:build amd64
 
 #include "textflag.h"
 
+// Classifying \w = [A-Za-z0-9_] with unsigned clamp-and-compare costs three
+// VPMINUB/VPMAXUB/VPCMPEQB triples plus a VPCMPEQB for '_' and three VPORs:
+// thirteen vector ops per 32 bytes, ten of them on the two general vector
+// ALU ports. A nibble table does the same job in six, and the two VPSHUFBs
+// it adds run on the otherwise idle shuffle port.
+//
+// The table splits each byte into its high and low nibble. Every high
+// nibble that contains word characters gets one bit:
+//
+//	0x3_ -> 0x01   0x4_ -> 0x02   0x5_ -> 0x04   0x6_ -> 0x08   0x7_ -> 0x10
+//
+// and each low-nibble entry carries the set of high-nibble rows in which
+// that low nibble is a word character, so a byte is a word character
+// exactly when lowTable[lo] & highTable[hi] != 0:
+//
+//	lo 0x0        -> 0x15   ('0', 'P', 'p')
+//	lo 0x1..0x9   -> 0x1F   (digits and letters in every row)
+//	lo 0xA        -> 0x1E   ('J', 'Z', 'j', 'z' but not ':')
+//	lo 0xB..0xE   -> 0x0A   ('K'..'N', 'k'..'n' only)
+//	lo 0xF        -> 0x0E   ('O', '_', 'o')
+//
+// Bytes >= 0x80 need no separate guard: VPSHUFB zeroes any lane whose
+// index byte has bit 7 set, so the low-nibble lookup already returns 0 for
+// them and they classify as non-word, matching the SWAR fallback.
+//
+// Both kernels compute the same "not a word character" mask (0xFF per
+// non-word lane): the low and high lookups are AND-ed and compared against
+// zero, which is the complement the class test needs anyway.
+// memchrNotWord ORs those masks together across a block and scans the
+// extracted bits directly; memchrWord ANDs them (a block holds a word
+// character exactly when some lane's non-word mask is clear) and inverts
+// the extracted bits with a single NOTL.
+
+// NOTWORD leaves in dst a mask with 0xFF in every lane of src that is NOT
+// a word character. t0 and t1 are scratch; dst may alias src.
+#define NOTWORD(src, dst, t0, t1) \
+	VPSRLW   $4, src, t0;  \
+	VPAND    Y2, t0, t0;   \
+	VPSHUFB  t0, Y1, t0;   \
+	VPSHUFB  src, Y0, t1;  \
+	VPAND    t0, t1, t0;   \
+	VPCMPEQB Y3, t0, dst
+
+// SETUPTABLES loads the nibble tables, the low-nibble mask and a zero
+// vector into Y0-Y3. The tables are built from immediates rather than a
+// RODATA section so the kernels stay position-independent and free of
+// relocations.
+#define SETUPTABLES \
+	MOVQ        $0x1F1F1F1F1F1F1F15, AX; \
+	VMOVQ       AX, X0;                  \
+	MOVQ        $0x0E0A0A0A0A1E1F1F, AX; \
+	VPINSRQ     $1, AX, X0, X0;          \
+	VINSERTI128 $1, X0, Y0, Y0;          \
+	MOVQ        $0x1008040201000000, AX; \
+	VMOVQ       AX, X1;                  \
+	VINSERTI128 $1, X1, Y1, Y1;          \
+	MOVQ        $0x0F0F0F0F0F0F0F0F, AX; \
+	VMOVQ       AX, X2;                  \
+	VPBROADCASTQ X2, Y2;                 \
+	VPXOR       Y3, Y3, Y3
+
 // func memchrWordAVX2(haystack []byte) int
 //
-// AVX2 implementation to find first word character [A-Za-z0-9_].
-// Processes 32 bytes per iteration using range comparisons.
-//
-// Algorithm for checking if byte B is in range [lo, hi]:
-//   clamped = max(min(B, hi), lo)
-//   inRange = (B == clamped) ? 0xFF : 0x00
-//
-// Word character = [A-Z] | [a-z] | [0-9] | '_'
+// AVX2 implementation to find the first word character [A-Za-z0-9_].
 //
 // Parameters:
 //   haystack_base+0(FP)  - pointer to haystack (8 bytes)
@@ -36,117 +92,70 @@ TEXT ·memchrWordAVX2(SB), NOSPLIT, $0-32
 	TESTQ   DX, DX
 	JZ      word_not_found
 
-	// Save start for offset calculation
+	// Save start for offset calculation and compute the end pointer
 	MOVQ    SI, DI                     // DI = start pointer
-
-	// Calculate end pointer
 	LEAQ    (SI)(DX*1), R8             // R8 = end pointer
 
-	// Broadcast range constants to YMM registers
-	// [A-Z]: 65-90
-	MOVQ    $65, AX
-	VMOVD   AX, X8
-	VPBROADCASTB X8, Y8                // Y8 = [65, 65, ...] = 'A'
+	CMPQ    DX, $32
+	JB      word_tail_loop             // sub-32 direct call: scalar
 
-	MOVQ    $90, AX
-	VMOVD   AX, X9
-	VPBROADCASTB X9, Y9                // Y9 = [90, 90, ...] = 'Z'
+	SETUPTABLES
 
-	// [a-z]: 97-122
-	MOVQ    $97, AX
-	VMOVD   AX, X10
-	VPBROADCASTB X10, Y10              // Y10 = [97, 97, ...] = 'a'
+	LEAQ    -32(R8), R12               // last valid 32-byte window base
+	LEAQ    -128(R8), R11              // last valid 128-byte block base
+	CMPQ    SI, R11
+	JA      word_loop32_entry
 
-	MOVQ    $122, AX
-	VMOVD   AX, X11
-	VPBROADCASTB X11, Y11              // Y11 = [122, 122, ...] = 'z'
+word_loop128:
+	VMOVDQU (SI), Y4
+	VMOVDQU 32(SI), Y5
+	VMOVDQU 64(SI), Y6
+	VMOVDQU 96(SI), Y7
+	NOTWORD(Y4, Y4, Y8, Y9)
+	NOTWORD(Y5, Y5, Y8, Y9)
+	NOTWORD(Y6, Y6, Y8, Y9)
+	NOTWORD(Y7, Y7, Y8, Y9)
 
-	// [0-9]: 48-57
-	MOVQ    $48, AX
-	VMOVD   AX, X12
-	VPBROADCASTB X12, Y12              // Y12 = [48, 48, ...] = '0'
+	// A word character exists in the block iff some lane's non-word mask
+	// is clear, so AND the four masks and look for a zero lane.
+	VPAND   Y4, Y5, Y8
+	VPAND   Y6, Y7, Y9
+	VPAND   Y8, Y9, Y8
+	VPMOVMSKB Y8, CX
+	NOTL    CX
+	TESTL   CX, CX
+	JNZ     word_found_in_block
 
-	MOVQ    $57, AX
-	VMOVD   AX, X13
-	VPBROADCASTB X13, Y13              // Y13 = [57, 57, ...] = '9'
+	ADDQ    $128, SI
+	CMPQ    SI, R11
+	JBE     word_loop128
 
-	// '_': 95
-	MOVQ    $95, AX
-	VMOVD   AX, X14
-	VPBROADCASTB X14, Y14              // Y14 = [95, 95, ...] = '_'
+word_loop32_entry:
+	CMPQ    SI, R12
+	JA      word_last32
 
 word_loop32:
-	// Check if we have at least 32 bytes remaining
-	LEAQ    32(SI), R9
-	CMPQ    R9, R8
-	JA      word_handle_tail
-
-	// Load 32 bytes
-	VMOVDQU (SI), Y0                   // Y0 = data
-
-	// Check [A-Z]: clamp to [65, 90], compare
-	VPMINUB Y0, Y9, Y1                 // Y1 = min(data, 90)
-	VPMAXUB Y1, Y8, Y1                 // Y1 = max(min(data, 90), 65)
-	VPCMPEQB Y0, Y1, Y2                // Y2 = (data == clamped) for [A-Z]
-
-	// Check [a-z]: clamp to [97, 122], compare
-	VPMINUB Y0, Y11, Y1                // Y1 = min(data, 122)
-	VPMAXUB Y1, Y10, Y1                // Y1 = max(min(data, 122), 97)
-	VPCMPEQB Y0, Y1, Y3                // Y3 = (data == clamped) for [a-z]
-
-	// Check [0-9]: clamp to [48, 57], compare
-	VPMINUB Y0, Y13, Y1                // Y1 = min(data, 57)
-	VPMAXUB Y1, Y12, Y1                // Y1 = max(min(data, 57), 48)
-	VPCMPEQB Y0, Y1, Y4                // Y4 = (data == clamped) for [0-9]
-
-	// Check '_'
-	VPCMPEQB Y0, Y14, Y5               // Y5 = (data == '_')
-
-	// Combine: Y2 | Y3 | Y4 | Y5
-	VPOR    Y2, Y3, Y6
-	VPOR    Y4, Y5, Y7
-	VPOR    Y6, Y7, Y6                 // Y6 = final result mask
-
-	// Extract mask
-	VPMOVMSKB Y6, CX
-
-	// Check if any match
+	VMOVDQU (SI), Y4
+	NOTWORD(Y4, Y4, Y8, Y9)
+	VPMOVMSKB Y4, CX
+	NOTL    CX
 	TESTL   CX, CX
 	JNZ     word_found_in_vector
 
-	// Advance to next chunk
 	ADDQ    $32, SI
-	JMP     word_loop32
+	CMPQ    SI, R12
+	JBE     word_loop32
 
-word_handle_tail:
-	// Fewer than 32 bytes remain. If any do, rescan the final 32-byte
-	// window ending at the buffer end: lanes before SI were already
-	// resolved as non-matching, so BSF stays exact. Inputs shorter than
-	// 32 bytes (unreachable through the Go dispatch) take the scalar loop.
+word_last32:
+	// Fewer than 32 bytes remain past SI; rescan the final window. Lanes
+	// before SI were already resolved as non-matching, so BSF stays exact.
 	CMPQ    SI, R8
 	JAE     word_not_found
-	CMPQ    DX, $32
-	JB      word_tail_loop              // sub-32 direct call: scalar
-
-	LEAQ    -32(R8), SI                 // SI = base of the final window
-	VMOVDQU (SI), Y0
-
-	// Same class checks as the main loop
-	VPMINUB Y0, Y9, Y1
-	VPMAXUB Y1, Y8, Y1
-	VPCMPEQB Y0, Y1, Y2                // [A-Z]
-	VPMINUB Y0, Y11, Y1
-	VPMAXUB Y1, Y10, Y1
-	VPCMPEQB Y0, Y1, Y3                // [a-z]
-	VPMINUB Y0, Y13, Y1
-	VPMAXUB Y1, Y12, Y1
-	VPCMPEQB Y0, Y1, Y4                // [0-9]
-	VPCMPEQB Y0, Y14, Y5               // '_'
-	VPOR    Y2, Y3, Y6
-	VPOR    Y4, Y5, Y7
-	VPOR    Y6, Y7, Y6
-
-	VPMOVMSKB Y6, CX
+	MOVQ    R12, SI
+	VMOVDQU (SI), Y4
+	NOTWORD(Y4, Y4, Y8, Y9)
+	VPMOVMSKB Y4, CX
+	NOTL    CX
 	TESTL   CX, CX
 	JNZ     word_found_in_vector
 	JMP     word_not_found
@@ -190,8 +199,28 @@ word_not_found:
 	VZEROUPPER
 	RET
 
+word_found_in_block:
+	// Locate the first hit by re-extracting the per-vector masks in
+	// address order; only one of the four can hold the lowest match.
+	VPMOVMSKB Y4, CX
+	NOTL    CX
+	TESTL   CX, CX
+	JNZ     word_found_in_vector
+	ADDQ    $32, SI
+	VPMOVMSKB Y5, CX
+	NOTL    CX
+	TESTL   CX, CX
+	JNZ     word_found_in_vector
+	ADDQ    $32, SI
+	VPMOVMSKB Y6, CX
+	NOTL    CX
+	TESTL   CX, CX
+	JNZ     word_found_in_vector
+	ADDQ    $32, SI
+	VPMOVMSKB Y7, CX
+	NOTL    CX
+
 word_found_in_vector:
-	// Find first set bit
 	BSFL    CX, BX
 	SUBQ    DI, SI                     // SI = offset to chunk start
 	ADDQ    SI, BX                     // BX = absolute position
@@ -205,13 +234,11 @@ word_found_scalar:
 	VZEROUPPER
 	RET
 
-
 // func memchrNotWordAVX2(haystack []byte) int
 //
-// AVX2 implementation to find first non-word character.
-// This is the complement of memchrWordAVX2.
-//
-// Non-word = NOT([A-Z] | [a-z] | [0-9] | '_')
+// AVX2 implementation to find the first non-word character, the complement
+// of memchrWordAVX2. The nibble classifier already produces the non-word
+// mask directly, so this kernel skips the NOTL memchrWordAVX2 needs.
 //
 TEXT ·memchrNotWordAVX2(SB), NOSPLIT, $0-32
 	// Load parameters
@@ -222,121 +249,63 @@ TEXT ·memchrNotWordAVX2(SB), NOSPLIT, $0-32
 	TESTQ   DX, DX
 	JZ      notword_not_found
 
-	// Save start for offset calculation
+	// Save start for offset calculation and compute the end pointer
 	MOVQ    SI, DI
-
-	// Calculate end pointer
 	LEAQ    (SI)(DX*1), R8
 
-	// Broadcast range constants
-	// [A-Z]: 65-90
-	MOVQ    $65, AX
-	VMOVD   AX, X8
-	VPBROADCASTB X8, Y8
+	CMPQ    DX, $32
+	JB      notword_tail_loop          // sub-32 direct call: scalar
 
-	MOVQ    $90, AX
-	VMOVD   AX, X9
-	VPBROADCASTB X9, Y9
+	SETUPTABLES
 
-	// [a-z]: 97-122
-	MOVQ    $97, AX
-	VMOVD   AX, X10
-	VPBROADCASTB X10, Y10
+	LEAQ    -32(R8), R12
+	LEAQ    -128(R8), R11
+	CMPQ    SI, R11
+	JA      notword_loop32_entry
 
-	MOVQ    $122, AX
-	VMOVD   AX, X11
-	VPBROADCASTB X11, Y11
+notword_loop128:
+	VMOVDQU (SI), Y4
+	VMOVDQU 32(SI), Y5
+	VMOVDQU 64(SI), Y6
+	VMOVDQU 96(SI), Y7
+	NOTWORD(Y4, Y4, Y8, Y9)
+	NOTWORD(Y5, Y5, Y8, Y9)
+	NOTWORD(Y6, Y6, Y8, Y9)
+	NOTWORD(Y7, Y7, Y8, Y9)
 
-	// [0-9]: 48-57
-	MOVQ    $48, AX
-	VMOVD   AX, X12
-	VPBROADCASTB X12, Y12
+	VPOR    Y4, Y5, Y8
+	VPOR    Y6, Y7, Y9
+	VPOR    Y8, Y9, Y8
+	VPMOVMSKB Y8, CX
+	TESTL   CX, CX
+	JNZ     notword_found_in_block
 
-	MOVQ    $57, AX
-	VMOVD   AX, X13
-	VPBROADCASTB X13, Y13
+	ADDQ    $128, SI
+	CMPQ    SI, R11
+	JBE     notword_loop128
 
-	// '_': 95
-	MOVQ    $95, AX
-	VMOVD   AX, X14
-	VPBROADCASTB X14, Y14
-
-	// All ones for NOT operation
-	VPCMPEQB Y15, Y15, Y15             // Y15 = [0xFF, 0xFF, ...]
+notword_loop32_entry:
+	CMPQ    SI, R12
+	JA      notword_last32
 
 notword_loop32:
-	// Check if we have at least 32 bytes remaining
-	LEAQ    32(SI), R9
-	CMPQ    R9, R8
-	JA      notword_handle_tail
-
-	// Load 32 bytes
-	VMOVDQU (SI), Y0
-
-	// Check [A-Z]
-	VPMINUB Y0, Y9, Y1
-	VPMAXUB Y1, Y8, Y1
-	VPCMPEQB Y0, Y1, Y2
-
-	// Check [a-z]
-	VPMINUB Y0, Y11, Y1
-	VPMAXUB Y1, Y10, Y1
-	VPCMPEQB Y0, Y1, Y3
-
-	// Check [0-9]
-	VPMINUB Y0, Y13, Y1
-	VPMAXUB Y1, Y12, Y1
-	VPCMPEQB Y0, Y1, Y4
-
-	// Check '_'
-	VPCMPEQB Y0, Y14, Y5
-
-	// Combine: isWord = Y2 | Y3 | Y4 | Y5
-	VPOR    Y2, Y3, Y6
-	VPOR    Y4, Y5, Y7
-	VPOR    Y6, Y7, Y6
-
-	// NOT: isNotWord = ~isWord
-	VPXOR   Y6, Y15, Y6                // Y6 = NOT(isWord)
-
-	// Extract mask
-	VPMOVMSKB Y6, CX
-
-	// Check if any match
+	VMOVDQU (SI), Y4
+	NOTWORD(Y4, Y4, Y8, Y9)
+	VPMOVMSKB Y4, CX
 	TESTL   CX, CX
 	JNZ     notword_found_in_vector
 
-	// Advance to next chunk
 	ADDQ    $32, SI
-	JMP     notword_loop32
+	CMPQ    SI, R12
+	JBE     notword_loop32
 
-notword_handle_tail:
-	// Overlapping vector tail; see word_handle_tail.
+notword_last32:
 	CMPQ    SI, R8
 	JAE     notword_not_found
-	CMPQ    DX, $32
-	JB      notword_tail_loop           // sub-32 direct call: scalar
-
-	LEAQ    -32(R8), SI                 // SI = base of the final window
-	VMOVDQU (SI), Y0
-
-	// Same class checks as the main loop, then complement
-	VPMINUB Y0, Y9, Y1
-	VPMAXUB Y1, Y8, Y1
-	VPCMPEQB Y0, Y1, Y2
-	VPMINUB Y0, Y11, Y1
-	VPMAXUB Y1, Y10, Y1
-	VPCMPEQB Y0, Y1, Y3
-	VPMINUB Y0, Y13, Y1
-	VPMAXUB Y1, Y12, Y1
-	VPCMPEQB Y0, Y1, Y4
-	VPCMPEQB Y0, Y14, Y5
-	VPOR    Y2, Y3, Y6
-	VPOR    Y4, Y5, Y7
-	VPOR    Y6, Y7, Y6
-	VPXOR   Y6, Y15, Y6                 // Y6 = NOT(isWord)
-
-	VPMOVMSKB Y6, CX
+	MOVQ    R12, SI
+	VMOVDQU (SI), Y4
+	NOTWORD(Y4, Y4, Y8, Y9)
+	VPMOVMSKB Y4, CX
 	TESTL   CX, CX
 	JNZ     notword_found_in_vector
 	JMP     notword_not_found
@@ -387,6 +356,21 @@ notword_not_found:
 	MOVQ    AX, ret+24(FP)
 	VZEROUPPER
 	RET
+
+notword_found_in_block:
+	VPMOVMSKB Y4, CX
+	TESTL   CX, CX
+	JNZ     notword_found_in_vector
+	ADDQ    $32, SI
+	VPMOVMSKB Y5, CX
+	TESTL   CX, CX
+	JNZ     notword_found_in_vector
+	ADDQ    $32, SI
+	VPMOVMSKB Y6, CX
+	TESTL   CX, CX
+	JNZ     notword_found_in_vector
+	ADDQ    $32, SI
+	VPMOVMSKB Y7, CX
 
 notword_found_in_vector:
 	BSFL    CX, BX

--- a/simd/memchr_digit.go
+++ b/simd/memchr_digit.go
@@ -12,9 +12,9 @@ import (
 // haystack, or -1 if no digit is present. Only ASCII digits match; Unicode
 // digit characters do not.
 //
-// On amd64 with AVX2 the range check runs on 32 bytes per iteration, which
-// is useful for locating numeric fields (ports, lengths, IP octets) in
-// request data.
+// On amd64 with AVX2 the range check runs on 32 bytes per vector, four
+// vectors per iteration, which is useful for locating numeric fields
+// (ports, lengths, IP octets) in request data.
 func MemchrDigit(haystack []byte) int {
 	if len(haystack) == 0 {
 		return -1
@@ -38,7 +38,8 @@ func MemchrDigitAt(haystack []byte, at int) int {
 
 // memchrDigitGeneric is the portable SWAR fallback for MemchrDigit: a
 // MatchRangeMask first-match scan (exact per lane; bytes >= 0x80 never
-// match), finishing 8+ byte inputs with one overlapping word at n-8.
+// match), two words per branch, finishing 8+ byte inputs with one
+// overlapping word at n-8.
 func memchrDigitGeneric(haystack []byte) int {
 	n := len(haystack)
 	if n < swar.WordLen {
@@ -50,6 +51,16 @@ func memchrDigitGeneric(haystack []byte) int {
 		return -1
 	}
 	i := 0
+	for ; i+2*swar.WordLen <= n; i += 2 * swar.WordLen {
+		m0 := swar.MatchRangeMask(swar.Load8(haystack, i), '0', '9')
+		m1 := swar.MatchRangeMask(swar.Load8(haystack, i+swar.WordLen), '0', '9')
+		if m0|m1 != 0 {
+			if m0 != 0 {
+				return i + swar.FirstLane(m0)
+			}
+			return i + swar.WordLen + swar.FirstLane(m1)
+		}
+	}
 	for ; i+swar.WordLen <= n; i += swar.WordLen {
 		if m := swar.MatchRangeMask(swar.Load8(haystack, i), '0', '9'); m != 0 {
 			return i + swar.FirstLane(m)

--- a/simd/memchr_digit.go
+++ b/simd/memchr_digit.go
@@ -52,8 +52,11 @@ func memchrDigitGeneric(haystack []byte) int {
 	}
 	i := 0
 	for ; i+2*swar.WordLen <= n; i += 2 * swar.WordLen {
-		m0 := swar.MatchRangeMask(swar.Load8(haystack, i), '0', '9')
-		m1 := swar.MatchRangeMask(swar.Load8(haystack, i+swar.WordLen), '0', '9')
+		// Pinned window: see the note above isASCIIGeneric in ascii.go for
+		// why the loads use constant offsets into it.
+		w := haystack[i : i+2*swar.WordLen : i+2*swar.WordLen]
+		m0 := swar.MatchRangeMask(swar.Load8(w, 0), '0', '9')
+		m1 := swar.MatchRangeMask(swar.Load8(w, swar.WordLen), '0', '9')
 		if m0|m1 != 0 {
 			if m0 != 0 {
 				return i + swar.FirstLane(m0)

--- a/simd/memchr_digit_amd64.go
+++ b/simd/memchr_digit_amd64.go
@@ -7,7 +7,8 @@
 package simd
 
 // memchrDigitAVX2 is implemented in memchr_digit_amd64.s. It finds bytes in
-// ['0','9'] via two signed VPCMPGTB range comparisons.
+// ['0','9'] via two signed VPCMPGTB range comparisons, four 32-byte vectors
+// per iteration.
 //
 //go:noescape
 func memchrDigitAVX2(haystack []byte) int

--- a/simd/memchr_digit_amd64.s
+++ b/simd/memchr_digit_amd64.s
@@ -2,27 +2,43 @@
 // (package simd), Copyright (c) 2025 Andrey Kolkov and contributors,
 // MIT License. See the LICENSE file in this directory for the full text.
 // Modified: legacy-SSE MOVD/MOVQ register moves replaced with VEX-encoded
-// VMOVD/VMOVQ to avoid AVX-SSE transition penalties on Intel CPUs, and the
+// VMOVD/VMOVQ to avoid AVX-SSE transition penalties on Intel CPUs, the
 // scalar tail loop replaced with one overlapping vector at the buffer end
-// for the MinLen+ inputs the Go dispatch guarantees.
+// for the MinLen+ inputs the Go dispatch guarantees, and the 32-byte main
+// loop replaced with a 4x unrolled 128-byte block.
 
 //go:build amd64
 
 #include "textflag.h"
 
+// DIGITS leaves in dst a mask with 0xFF in every lane of src holding an
+// ASCII digit. t0 and t1 are scratch; dst may alias src.
+//
+//	Y0 = [0x2F x 32] ('0' - 1)   Y1 = [0x39 x 32] ('9')
+//
+// VPCMPGTB is a signed comparison, which is what makes the pair exact for
+// every byte: lanes >= 0x80 are negative and so fail "> 0x2F" outright.
+#define DIGITS(src, dst, t0, t1) \
+	VPCMPGTB Y0, src, t0; \
+	VPCMPGTB Y1, src, t1; \
+	VPANDN   t0, t1, dst
+
 // func memchrDigitAVX2(haystack []byte) int
 //
 // AVX2 implementation of digit search that finds the first ASCII digit [0-9].
-// Processes 32 bytes per iteration using 256-bit vector range comparison.
 //
 // Algorithm for range check [0-9] (bytes 0x30-0x39):
 //  1. Broadcast 0x2F ('0'-1) and 0x39 ('9') to YMM registers
 //  2. Load 32 bytes from haystack
 //  3. VPCMPGTB: check if chunk > 0x2F (byte >= '0')
 //  4. VPCMPGTB: check if 0x39 < chunk, then invert (byte <= '9')
-//  5. VPAND: combine masks to get bytes in range ['0'-'9']
+//  5. VPANDN: combine masks to get bytes in range ['0'-'9']
 //  6. VPMOVMSKB: extract 32-bit mask
-//  7. TZCNT/BSFL: find first set bit
+//  7. BSFL: find first set bit
+//
+// The block loop runs steps 2-5 over four vectors, ORs the four masks and
+// extracts once; the (rare) hit path re-extracts the per-vector masks in
+// address order to locate the first digit.
 //
 // Parameters (FP offsets):
 //   haystack_base+0(FP)  - pointer to haystack data (8 bytes)
@@ -42,10 +58,6 @@ TEXT ·memchrDigitAVX2(SB), NOSPLIT, $0-32
 
 	// Prepare constants for range check ['0'-'9'] = [0x30-0x39]
 	// We check: byte > 0x2F AND byte <= 0x39
-	// Which is: byte > 0x2F AND NOT(byte > 0x39)
-	//
-	// Y0 = 0x2F repeated (low bound - 1, i.e., '0' - 1)
-	// Y1 = 0x39 repeated (high bound, i.e., '9')
 	MOVQ    $0x2F2F2F2F2F2F2F2F, AX
 	VMOVQ   AX, X0
 	VPBROADCASTQ X0, Y0                  // Y0 = [0x2F x 32]
@@ -54,63 +66,63 @@ TEXT ·memchrDigitAVX2(SB), NOSPLIT, $0-32
 	VMOVQ   AX, X1
 	VPBROADCASTQ X1, Y1                  // Y1 = [0x39 x 32]
 
-	// Save start pointer for offset calculation
+	// Save start pointer for offset calculation, compute the end pointer
 	MOVQ    SI, DI                       // DI = haystack start (preserved)
-
-	// Calculate end pointer
 	LEAQ    (SI)(DX*1), R8               // R8 = SI + length (end pointer)
 
-// Main loop: process 32 bytes per iteration
-loop32:
-	// Check if we have at least 32 bytes remaining
-	LEAQ    32(SI), R9                   // R9 = SI + 32
-	CMPQ    R9, R8                       // Compare with end pointer
-	JA      handle_tail                  // If R9 > R8, less than 32 bytes left
-
-	// Load 32 bytes from haystack (unaligned load is safe and fast with AVX2)
-	VMOVDQU (SI), Y2                     // Y2 = haystack[SI:SI+32]
-
-	// Range check: '0' <= byte <= '9'
-	//
-	// Step 1: Y3 = (byte > 0x2F) - bytes that are >= '0' have 0xFF, else 0x00
-	// VPCMPGTB sets each byte to 0xFF if Y2[i] > Y0[i], else 0x00
-	VPCMPGTB Y0, Y2, Y3                  // Y3 = (chunk > 0x2F)
-
-	// Step 2: Y4 = (byte > 0x39) - bytes that are > '9' have 0xFF, else 0x00
-	VPCMPGTB Y1, Y2, Y4                  // Y4 = (chunk > 0x39)
-
-	// Step 3: Y5 = Y3 AND NOT(Y4)
-	// This gives us: (byte > 0x2F) AND (byte <= 0x39) = digit in range
-	// VPANDN: Y5 = NOT(Y4) AND Y3
-	VPANDN  Y3, Y4, Y5                   // Y5 = (~Y4) & Y3 = digit mask
-
-	// Extract mask: bit i set if byte i is a digit
-	VPMOVMSKB Y5, CX                     // CX = 32-bit mask
-
-	// Check if any digit found (mask != 0)
-	TESTL   CX, CX
-	JNZ     found_in_vector              // Non-zero mask means digit found
-
-	// No digit in this chunk, advance to next 32 bytes
-	ADDQ    $32, SI
-	JMP     loop32
-
-handle_tail:
-	// Fewer than 32 bytes remain. If any do, rescan the final 32-byte
-	// window ending at the buffer end: lanes before SI were already
-	// resolved as non-digits, so BSF stays exact. Inputs shorter than 32
-	// bytes (unreachable through the Go dispatch) take the scalar loop.
-	CMPQ    SI, R8
-	JAE     not_found                    // If SI >= end, no bytes left
 	CMPQ    DX, $32
 	JB      tail_loop                    // sub-32 direct call: scalar
 
-	LEAQ    -32(R8), SI                  // SI = base of the final window
+	LEAQ    -32(R8), R12                 // last valid 32-byte window base
+	LEAQ    -128(R8), R11                // last valid 128-byte block base
+	CMPQ    SI, R11
+	JA      loop32_entry
+
+loop128:
 	VMOVDQU (SI), Y2
-	VPCMPGTB Y0, Y2, Y3                  // Y3 = (chunk > 0x2F)
-	VPCMPGTB Y1, Y2, Y4                  // Y4 = (chunk > 0x39)
-	VPANDN  Y3, Y4, Y5                   // Y5 = (~Y4) & Y3 = digit mask
-	VPMOVMSKB Y5, CX
+	VMOVDQU 32(SI), Y3
+	VMOVDQU 64(SI), Y4
+	VMOVDQU 96(SI), Y5
+	DIGITS(Y2, Y2, Y6, Y7)
+	DIGITS(Y3, Y3, Y6, Y7)
+	DIGITS(Y4, Y4, Y6, Y7)
+	DIGITS(Y5, Y5, Y6, Y7)
+
+	VPOR    Y2, Y3, Y6
+	VPOR    Y4, Y5, Y7
+	VPOR    Y6, Y7, Y6
+	VPMOVMSKB Y6, CX
+	TESTL   CX, CX
+	JNZ     found_in_block
+
+	ADDQ    $128, SI
+	CMPQ    SI, R11
+	JBE     loop128
+
+loop32_entry:
+	CMPQ    SI, R12
+	JA      last32
+
+loop32:
+	VMOVDQU (SI), Y2
+	DIGITS(Y2, Y2, Y6, Y7)
+	VPMOVMSKB Y2, CX
+	TESTL   CX, CX
+	JNZ     found_in_vector
+
+	ADDQ    $32, SI
+	CMPQ    SI, R12
+	JBE     loop32
+
+last32:
+	// Fewer than 32 bytes remain past SI; rescan the final window. Lanes
+	// before SI were already resolved as non-digits, so BSF stays exact.
+	CMPQ    SI, R8
+	JAE     not_found
+	MOVQ    R12, SI
+	VMOVDQU (SI), Y2
+	DIGITS(Y2, Y2, Y6, Y7)
+	VPMOVMSKB Y2, CX
 	TESTL   CX, CX
 	JNZ     found_in_vector
 	JMP     not_found
@@ -144,17 +156,29 @@ not_found:
 	VZEROUPPER                           // Clear upper YMM bits (CRITICAL!)
 	RET
 
-found_in_vector:
-	// Digit found in vector! CX contains 32-bit mask with set bits at digit positions.
-	// Use BSFL (Bit Scan Forward Long) to find index of first set bit.
-	//
-	// BSFL: scans from bit 0 upward, finds first 1 bit, stores its index in destination
-	// Example: CX = 0x00000010 (bit 4 set) -> BX = 4
-	BSFL    CX, BX                       // BX = index of first set bit (0-31)
+found_in_block:
+	// Locate the first digit by re-extracting the per-vector masks in
+	// address order; only one of the four can hold the lowest match.
+	VPMOVMSKB Y2, CX
+	TESTL   CX, CX
+	JNZ     found_in_vector
+	ADDQ    $32, SI
+	VPMOVMSKB Y3, CX
+	TESTL   CX, CX
+	JNZ     found_in_vector
+	ADDQ    $32, SI
+	VPMOVMSKB Y4, CX
+	TESTL   CX, CX
+	JNZ     found_in_vector
+	ADDQ    $32, SI
+	VPMOVMSKB Y5, CX
 
-	// Calculate absolute index in haystack
+found_in_vector:
+	// Digit found in vector! CX contains a 32-bit mask with set bits at
+	// digit positions; BSFL finds the index of the first one.
+	BSFL    CX, BX                       // BX = index of first set bit (0-31)
 	SUBQ    DI, SI                       // SI = offset from start to current chunk
-	ADDQ    SI, BX                       // BX = absolute index (chunk_offset + bit_position)
+	ADDQ    SI, BX                       // BX = absolute index
 	MOVQ    BX, ret+24(FP)               // Return index
 	VZEROUPPER                           // Clear upper YMM bits
 	RET

--- a/simd/simd.go
+++ b/simd/simd.go
@@ -7,9 +7,13 @@
 // FirstNonASCII, and CountNonASCII — dispatch to AVX2 assembly on amd64
 // CPUs (for inputs of MinLen+ bytes) and fall back to portable SWAR loops
 // built on the swar package everywhere else. The kernels consume four
-// 32-byte vectors per iteration, combining the per-vector masks so a
-// 128-byte block costs one mask extraction and one branch; the first-match
-// scans then re-extract the four masks in address order to locate the hit.
+// 32-byte vectors per iteration. The first-match scans and IsASCII combine
+// the per-vector masks, so a 128-byte block costs one mask extraction and
+// one branch, and the scans that report a position then re-extract the
+// four masks in address order to locate the hit. CountNonASCII is the
+// exception: a count cannot be recovered from a combined mask, so it
+// extracts and population-counts all four (and, unlike the others, gates
+// on POPCNT as well as AVX2).
 // Memmem prefilters 128+ byte haystacks on amd64 — needles of 2-6 bytes
 // containing two distinct values through the MemchrPair kernel, longer or
 // single-valued needles through a single rare-byte bytes.IndexByte scan —

--- a/simd/simd.go
+++ b/simd/simd.go
@@ -3,19 +3,21 @@
 // scans, paired-byte scans, substring search, and ASCII validation.
 //
 // Acceleration comes in two tiers. The scan kernels — Memchr2, Memchr3,
-// MemchrPair, MemchrDigit, MemchrWord, MemchrNotWord, and IsASCII —
-// dispatch to AVX2 assembly processing 32 bytes per iteration on amd64
+// MemchrPair, MemchrDigit, MemchrWord, MemchrNotWord, IsASCII,
+// FirstNonASCII, and CountNonASCII — dispatch to AVX2 assembly on amd64
 // CPUs (for inputs of MinLen+ bytes) and fall back to portable SWAR loops
-// built on the swar package everywhere else. Memmem prefilters 128+ byte
-// haystacks on amd64 — needles of 2-6 bytes containing two distinct
-// values through the MemchrPair kernel, longer or single-valued needles
-// through a single rare-byte bytes.IndexByte scan — and delegates to
-// bytes.Index for shorter haystacks or without AVX2.
-// FirstNonASCII and CountNonASCII are SWAR-only (8 bytes per iteration, no
-// assembly kernel), and MemchrInTable/MemchrNotInTable are plain scalar
-// loops, since an arbitrary 256-entry membership test has no cheap vector
-// form. Accelerated reports whether the AVX2 tier is active. Single-byte
-// search is deliberately absent: bytes.IndexByte is already
+// built on the swar package everywhere else. The kernels consume four
+// 32-byte vectors per iteration, combining the per-vector masks so a
+// 128-byte block costs one mask extraction and one branch; the first-match
+// scans then re-extract the four masks in address order to locate the hit.
+// Memmem prefilters 128+ byte haystacks on amd64 — needles of 2-6 bytes
+// containing two distinct values through the MemchrPair kernel, longer or
+// single-valued needles through a single rare-byte bytes.IndexByte scan —
+// and delegates to bytes.Index for shorter haystacks or without AVX2.
+// MemchrInTable/MemchrNotInTable are plain scalar loops on every
+// architecture, since an arbitrary 256-entry membership test has no cheap
+// vector form. Accelerated reports whether the AVX2 tier is active.
+// Single-byte search is deliberately absent: bytes.IndexByte is already
 // vector-accelerated by the Go runtime on all major architectures.
 //
 // Unlike the top-level utils helpers, this package operates on []byte only —

--- a/simd/simd_test.go
+++ b/simd/simd_test.go
@@ -250,8 +250,29 @@ func Test_FirstNonASCII_CountNonASCII(t *testing.T) {
 			}
 		}
 		require.Equal(t, wantFirst, FirstNonASCII(h), "size %d", n)
+		require.Equal(t, wantFirst, firstNonASCIIGeneric(h), "generic size %d", n)
 		require.Equal(t, wantCount, CountNonASCII(h), "size %d", n)
+		require.Equal(t, wantCount, countNonASCIIGeneric(h), "generic size %d", n)
 		require.Equal(t, wantFirst == -1, IsASCII(h), "size %d", n)
+
+		// A single non-ASCII byte at every position: the position has to
+		// survive the block loop's combined test and the per-vector
+		// re-extraction that locates it, and CountNonASCII has to find it
+		// whether it lands in the vector-aligned prefix or the SWAR tail.
+		clean := make([]byte, n)
+		for i := range clean {
+			clean[i] = byte(i % 0x80)
+		}
+		require.Equal(t, -1, FirstNonASCII(clean), "clean size %d", n)
+		require.Equal(t, 0, CountNonASCII(clean), "clean size %d", n)
+		for pos := range n {
+			h := bytes.Clone(clean)
+			h[pos] = 0xc3
+			require.Equal(t, pos, FirstNonASCII(h), "size %d pos %d", n, pos)
+			require.Equal(t, pos, firstNonASCIIGeneric(h), "generic size %d pos %d", n, pos)
+			require.Equal(t, 1, CountNonASCII(h), "size %d pos %d", n, pos)
+			require.Equal(t, 1, countNonASCIIGeneric(h), "generic size %d pos %d", n, pos)
+		}
 	}
 }
 
@@ -325,6 +346,35 @@ func Test_MemchrWord_NotWord(t *testing.T) {
 		}
 		require.Equal(t, wantWord, MemchrWord(h), "byte %#x", b)
 		require.Equal(t, wantNot, MemchrNotWord(h), "byte %#x", b)
+	}
+	// Every byte value again, this time inside a buffer long enough to
+	// reach the vector kernels (and past the 128-byte block loop), so the
+	// class table is checked for all 256 values and not just at length 1.
+	for b := range 256 {
+		for _, size := range []int{32, 33, 63, 64, 129, 200} {
+			for _, pos := range []int{0, 1, 31, 32, size - 1} {
+				if pos >= size {
+					continue
+				}
+				word := bytes.Repeat([]byte{' '}, size)
+				word[pos] = byte(b)
+				wantWord := -1
+				if refIsWord(byte(b)) {
+					wantWord = pos
+				}
+				require.Equal(t, wantWord, MemchrWord(word), "byte %#x size %d pos %d", b, size, pos)
+				require.Equal(t, wantWord, memchrWordGeneric(word), "generic byte %#x size %d pos %d", b, size, pos)
+
+				not := bytes.Repeat([]byte{'k'}, size)
+				not[pos] = byte(b)
+				wantNot := pos
+				if refIsWord(byte(b)) {
+					wantNot = -1
+				}
+				require.Equal(t, wantNot, MemchrNotWord(not), "byte %#x size %d pos %d", b, size, pos)
+				require.Equal(t, wantNot, memchrNotWordGeneric(not), "generic byte %#x size %d pos %d", b, size, pos)
+			}
+		}
 	}
 	for _, n := range testSizes {
 		nonWord := bytes.Repeat([]byte{' '}, n)

--- a/simd/simd_test.go
+++ b/simd/simd_test.go
@@ -77,6 +77,25 @@ func refIsASCII(h []byte) bool {
 	return true
 }
 
+func refFirstNonASCII(h []byte) int {
+	for i, b := range h {
+		if b >= 0x80 {
+			return i
+		}
+	}
+	return -1
+}
+
+func refCountNonASCII(h []byte) int {
+	n := 0
+	for _, b := range h {
+		if b >= 0x80 {
+			n++
+		}
+	}
+	return n
+}
+
 func checkMemchr2(t *testing.T, h []byte, a, b byte) {
 	t.Helper()
 	want := refMemchr2(h, a, b)
@@ -266,12 +285,13 @@ func Test_FirstNonASCII_CountNonASCII(t *testing.T) {
 		require.Equal(t, -1, FirstNonASCII(clean), "clean size %d", n)
 		require.Equal(t, 0, CountNonASCII(clean), "clean size %d", n)
 		for pos := range n {
-			h := bytes.Clone(clean)
-			h[pos] = 0xc3
-			require.Equal(t, pos, FirstNonASCII(h), "size %d pos %d", n, pos)
-			require.Equal(t, pos, firstNonASCIIGeneric(h), "generic size %d pos %d", n, pos)
-			require.Equal(t, 1, CountNonASCII(h), "size %d pos %d", n, pos)
-			require.Equal(t, 1, countNonASCIIGeneric(h), "generic size %d pos %d", n, pos)
+			orig := clean[pos]
+			clean[pos] = 0xc3
+			require.Equal(t, pos, FirstNonASCII(clean), "size %d pos %d", n, pos)
+			require.Equal(t, pos, firstNonASCIIGeneric(clean), "generic size %d pos %d", n, pos)
+			require.Equal(t, 1, CountNonASCII(clean), "size %d pos %d", n, pos)
+			require.Equal(t, 1, countNonASCIIGeneric(clean), "generic size %d pos %d", n, pos)
+			clean[pos] = orig
 		}
 	}
 }
@@ -691,8 +711,12 @@ func Test_Accelerated(t *testing.T) {
 func Test_TestSizesCoverDispatchBoundaries(t *testing.T) {
 	t.Parallel()
 	// Guard the sweep against accidental edits: it must include sub-word,
-	// word-with-tail, exactly-one-vector, and beyond-crossover sizes.
-	for _, must := range []int{0, 7, 8, 31, 32, 33, 63, 64, 127, 128, 512} {
+	// word-with-tail, exactly-one-vector, whole-and-partial 128-byte
+	// block, and beyond-crossover sizes. 129/130/200 are what exercise the
+	// kernels' block loop handing off to the 32-byte loop and then to the
+	// overlapping final window; 128 and 512 divide evenly and leave both
+	// of those untouched.
+	for _, must := range []int{0, 7, 8, 31, 32, 33, 63, 64, 127, 128, 129, 130, 200, 512} {
 		require.Contains(t, testSizes, must, strconv.Itoa(must))
 	}
 }

--- a/swar/swar.go
+++ b/swar/swar.go
@@ -44,6 +44,22 @@ const (
 // reslice pins the length so the constant-index reads are bounds-check free,
 // and the compiler fuses them into a single 8-byte load on little-endian
 // targets (verified for both the string and []byte instantiations).
+//
+// The reslice itself is still checked, against the backing array's
+// capacity, which a loop condition written in terms of len does not imply.
+// A loop that loads several words per iteration should therefore pin the
+// whole group once and index into it with constants rather than call Load8
+// at a variable offset each time:
+//
+//	for ; i+4*WordLen <= n; i += 4 * WordLen {
+//		w := b[i : i+4*WordLen : i+4*WordLen]
+//		acc := Load8(w, 0) | Load8(w, WordLen) | Load8(w, 2*WordLen) | Load8(w, 3*WordLen)
+//		// ...
+//	}
+//
+// That moves four checks and their empty-slice pointer clamps down to one
+// per group; on []byte the three-index form pins the capacity too and
+// removes the rest. It is worth 20-60% on the word loops in package simd.
 func Load8[S ~string | ~[]byte](s S, i int) uint64 {
 	w := s[i : i+8]
 	return uint64(w[0]) |


### PR DESCRIPTION
Three related changes to package `simd` and the SWAR word loops it is built on, plus one memory-safety fix found while reviewing the first of them.

## 1. AVX2 kernels: 128-byte blocks

Every scan kernel consumed one 32-byte vector per iteration and spent five scalar instructions per vector on loop bookkeeping, so the port-0 `VPMOVMSKB` and the loop branch sat on the critical path of every chunk.

Each kernel now classifies four vectors per iteration and combines their masks, so a 128-byte block costs one extraction and one branch, and both loops test their bound at the bottom against a precomputed limit pointer. The scans that report a position keep the four per-vector masks live and re-extract them in address order on the (rare) hit path, so reported indices are unchanged.

## 2. `\w` classifier: nibble tables instead of clamp-and-compare

`memchrWord`/`memchrNotWord` classified `\w` with three `VPMINUB`/`VPMAXUB` range tests plus a `VPCMPEQB` and three `VPOR`s — thirteen vector ops per 32 bytes, ten of them on the two general vector ALU ports. A pair of `VPSHUFB` nibble-table lookups does the same job in six and puts the lookups on the otherwise idle shuffle port. The tables are built from immediates, so the kernels stay free of relocations.

## 3. `FirstNonASCII` and `CountNonASCII` were SWAR-only

Both now have kernels. Counting cannot finish with the overlapping final window the first-match scans use — it would double-count — so its kernel stops at the last whole vector and takes the remaining 0-31 bytes with a branch-free byte loop.

## 4. SWAR fallbacks: pinned load windows

`swar.Load8`'s reslice is bounds-checked against the backing array's **capacity**, which a loop condition written in terms of **length** does not imply. So every variable-index load cost a compare, a branch and a four-instruction empty-slice pointer clamp — in a 32-byte loop body, more scaffolding than work.

Pinning the whole group once with a three-index reslice and indexing it with constants folds all of that away. This turned out to be the single largest win in the PR for the portable paths. `swar.Load8`'s doc now describes the pattern so downstream callers can use it, and `utils.IsASCII` — a separately maintained copy of the same scan — gets the same rework so the two stay in step.

## Bug fix: `countNonASCIIAVX2` read past the slice

Caught while reviewing the above. It was the one kernel in the package relying on a caller-side length invariant instead of clamping itself: its 32-byte loop tested `base < end` rather than `base <= end-32`, so any length not a multiple of 32 read whole vectors past the slice — 24 bytes past a 40-byte input, and a SIGSEGV when the slice ended on a page boundary. The only caller masked the length, so nothing in the suite reached it.

Making the kernel self-bounding removed the precondition, the `vectorLen` constant that encoded it, and the Go-side prefix/suffix split. Dropping that split also removed a second non-inlinable call from every whole-vector input — enough that counting had been *slower than its own SWAR fallback* at `MinLen` (11.3ns vs 8.8ns at 32B). They are level at 32B now and the kernel leads from 64B up.

`simd/guard_amd64_test.go` covers this by placing the input's last byte flush against a `PROT_NONE` page and calling each kernel directly, so an over-read faults instead of landing on zero-filled allocator slack. It reproduces the original crash when the fix is reverted.

Separately, `POPCNT` is a distinct CPUID bit from AVX2 and this kernel is the only one that leaves the AVX/AVX2 instruction set, so the count dispatch now gates on `cpu.X86.HasPOPCNT` too — a masked-CPUID guest gets the SWAR path instead of `SIGILL`.

## Benchmarks

`benchstat -count=10`, merge-base vs head, both sides measured back to back in one session on the same machine. `goos: linux, goarch: amd64, cpu: Intel(R) Xeon(R) @ 2.80GHz (AVX2), -4`.

**AVX2 kernels** (`/simd` legs, ns/op):

| | 512B | 4096B |
|---|---|---|
| `Memchr2` | −26.2% | −49.3% |
| `Memchr3` | −19.4% | −34.5% |
| `MemchrPair` | −12.8% | −25.8% |
| `MemchrDigit` | −42.1% | −57.7% |
| `MemchrNotWord` | −53.4% | −62.8% |
| `IsASCII` | −39.7% | −64.3% |
| `Memmem` | −8.0% | −23.8% |
| `Memmem` prefilter (paired) | −12.9% | −23.6% |

`MemchrPair` also improves at 8B (−20.1%) and 64B (−10.5%); `MemchrNotWord` at 32B (−11.7%) and 64B (−15.4%); `Memmem_Adversarial` −5.1%.

**SWAR fallbacks** (the portable paths, and what every non-amd64 build runs):

| | 32B | 512B | 4096B |
|---|---|---|---|
| `IsASCII` | −35.6% | −71.9% | −73.4% |
| `MemchrDigit` | −22.6% | −25.6% | −32.1% |
| `MemchrNotWord` | −6.2% | −4.6% | −6.0% |

`IsASCII`'s fallback also improves 26.9% at 8B and 51.9% at 64B. `Memchr2`/`Memchr3` gained fallback benchmark legs in this PR so they have no merge-base row; measured against their pre-window state in a separate paired run they are −19%/−23%/−25% and −8%/−13%/−18% at 32B/512B/4KiB.

**Newly accelerated** (no baseline — these had no kernel before), AVX2 vs the SWAR fallback in the same tree:

| | 512B | 4096B |
|---|---|---|
| `MemchrWord` | 20.1ns vs 358ns (17.8×) | 115ns vs 2.84µs (24.8×) |
| `FirstNonASCII` | 12.0ns vs 53.2ns (4.5×) | 65.4ns vs 338ns (5.2×) |
| `CountNonASCII` | 14.4ns vs 54.3ns (3.8×) | 61.3ns vs 411ns (6.7×) |

**Where it does not help, and how much to trust the small numbers.** Inputs below `simd.MinLen` never reach the kernels. Inputs of 32-127 bytes reach them but skip the block loop, so they pay its setup with nothing to amortize it — mostly a wash, with the class scans ahead and a couple of rows a few percent down.

Those small-input figures should be read against the run's own noise floor. The `default` legs call unchanged stdlib code, so their movement bounds what a delta of that size means. In the run behind the README's per-size claims they held within 1%; in this end-to-end run they drifted up to 17% at 32B (`Memchr3/32B/default` −16.7% on code this PR does not touch). At 512B and above the controls are within ~1%, so the large-input deltas above are solid. Anything under ~10% at 8-64B should be read as "no measured change".

The README benchmark block is regenerated, and its prose now states the deltas come from `benchstat -count=10` — the single-run table is a catalog and subtracting its rows from an older copy will not reproduce them.

## Tests

- `guard_amd64_test.go`: every kernel called directly with its last byte against an unmapped page, at 26 lengths covering every sub-vector and sub-block remainder; plus an exact-count sweep for the counting kernel at every length 0-399.
- `FuzzMemchrClass` (new): the hand-built `VPSHUFB` nibble tables against the SWAR range masks — two independent derivations of one character class.
- `FuzzIsASCII` now checks `FirstNonASCII`'s **index** and `CountNonASCII`'s **value** against references, not just their consistency with `IsASCII`.
- All-256-byte-value sweeps across vector and block boundaries for the class kernels; per-position sweeps for the two new ASCII kernels; the dispatch-boundary guard now requires the sizes that exercise the block loop handing off to the 32-byte loop.
- New benchmarks for `MemchrWord`, `FirstNonASCII`, `CountNonASCII`, plus fallback comparison legs for `Memchr2`/`Memchr3`.

Also verified while developing: exhaustive sweeps over every length ≤400 × every match position × 11 byte values against scalar references, `-race -shuffle=on` across the module, all six fuzz targets, `go vet` on amd64 and arm64, 386 cross-build, `gofumpt` and `golangci-lint` clean.

## Not in this PR

The 128-byte block skeleton and the four-arm hit ladder are hand-copied across six kernels and would collapse into assembler macros — the same commit already introduces `NOTWORD`, `DIGITS` and `SETUPTABLES`, so the mechanism is established. That is a large-blast-radius refactor of assembly that is now verified working, so it belongs in its own change with its own verification rather than folded in here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved ASCII detection and non-ASCII finding/counting with AVX2-backed kernels (including POPCNT gating) and faster portable fallbacks.
  * Enhanced character-class, digit, and word/not-word searches by expanding the amount scanned per iteration and refining tail handling.
* **Documentation**
  * Refreshed SIMD tiering descriptions and benchmark results for non-ASCII operations.
* **Testing**
  * Added new fuzz targets and scalar/bench comparisons for non-ASCII and word-related searches.
  * Introduced self-bounding kernel tests to ensure no out-of-bounds reads, plus exact-count validation for AVX2 scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->