### PR TITLE
⚡ perf: Faster IndexControl, AppendDuration, GetMIME; simplify the helpers added in #247

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,7 +542,9 @@ below 0x20 or DEL (0x7F), the RFC 5234 CTL set — and `IndexControlExceptTab`
 is the same scan with HTAB permitted, which is the byte set an RFC 9110
 field value may not contain. Both are SWAR first-match scans
 (two words per branch, one overlapping word for the tail) over strings or
-byte slices, and they never match bytes >= 0x80, so unlike
+byte slices; the HTAB exemption is tested only in words that hold a
+control byte, so clean input costs the same either way. They never match
+bytes >= 0x80, so unlike
 `strings.IndexFunc(s, unicode.IsControl)` they neither decode UTF-8 nor
 flag the C1 range hidden inside it. Fiber spells this check by hand in
 half a dozen places — header values before they are echoed, request IDs,
@@ -583,17 +585,18 @@ elements skipped — how HTTP list fields such as `Accept-Encoding`,
 5.6.1: optional whitespace around the commas, empty elements ignored).
 It replaces the `strings.SplitSeq` + `TrimSpace` + emptiness-check
 triplet, locates each separator with a single `IndexByte`, works on
-strings and byte slices alike, and yields subslices without copying. The
-range-over-func machinery costs the same handful of allocations as
-`strings.SplitSeq`, so this is an ergonomic helper first and a modest
-(single-digit percent) speedup second; a caller that must avoid the
-iterator allocations entirely can loop over `CutByte` and `TrimSpace`.
+strings and byte slices alike, and yields subslices without copying. In
+an ordinary caller the iterator inlines and allocates nothing, like
+`strings.SplitSeq`; the benchmark ranges inside a helper function for
+that reason, because calls made directly inside a `b.Loop` body are
+never inlined and would show the closure allocations instead.
 
 ## Duration formatting
 
 `AppendDuration` renders a `time.Duration` exactly as `d.String()` does —
 "72h3m0.5s", "1.5ms", "0s" — into the caller's buffer, with the two-digit
-table for the field digits. `d.String()` allocates its result and
+table for the field digits; a value with no fraction, the common case,
+never touches the fraction digits. `d.String()` allocates its result and
 `fmt.Fprintf("%v", d)`, which Fiber's logger uses for the latency column,
 costs several times more on top; an append-style form makes per-request
 duration rendering (access logs, `Server-Timing`) allocation-free.
@@ -611,8 +614,9 @@ found with a trailing-zero count. Values below 100 come from a
 precomputed table, and the output is pinned to `strconv` by a dense sweep
 plus every decimal and lane-group boundary. `GetMIME` in the same spirit
 looks up extensions through a hash table keyed by the extension packed
-into one lower-cased word, so a hit is a multiply, a shift, and one slot
-comparison, with no allocation even for upper-case input.
+into one lower-cased word with its length in the top lane, so a hit is a
+multiply, a shift, and one slot comparison, with no allocation even for
+upper-case input.
 
 These helpers were added on an amd64 machine, so like the `simd` numbers
 their benchmarks are recorded separately from the arm64 catalog above and
@@ -628,125 +632,125 @@ pkg: github.com/gofiber/utils/v2
 cpu: Intel(R) Xeon(R) Processor @ 2.80GHz
 
 ```text
-// go test -benchmem -run=^$ -count=1 . -bench='Benchmark_(Format(U|I)nt(32|16)?|Append(U|I)nt|EqualFold_Short|GetMIME|(Append|Parse)HTTPDate|AppendDuration|Append(Query|Path)(Un)?escape|AppendJSONString|ParseIPv[46]|CanonicalHeaderKey|IndexControl|(Last)?CutByte|SplitHostPort|SplitTrimSeq)'
-Benchmark_EqualFold_Short/3B/fiber-4                               325323405    3.679  ns/op     0  B/op   0  allocs/op
-Benchmark_EqualFold_Short/3B/default-4                             251649547    4.611  ns/op     0  B/op   0  allocs/op
-Benchmark_EqualFold_Short/4B/fiber-4                               306784155    3.567  ns/op     0  B/op   0  allocs/op
-Benchmark_EqualFold_Short/4B/default-4                             260997692    4.483  ns/op     0  B/op   0  allocs/op
-Benchmark_EqualFold_Short/5B/fiber-4                               315655149    3.913  ns/op     0  B/op   0  allocs/op
-Benchmark_EqualFold_Short/5B/default-4                             273075318    4.402  ns/op     0  B/op   0  allocs/op
-Benchmark_EqualFold_Short/7B/fiber-4                               305564444    3.812  ns/op     0  B/op   0  allocs/op
-Benchmark_EqualFold_Short/7B/default-4                             259026663    4.829  ns/op     0  B/op   0  allocs/op
-Benchmark_EqualFold_Short/8B/fiber-4                               326015097    3.345  ns/op     0  B/op   0  allocs/op
-Benchmark_EqualFold_Short/8B/default-4                             172114417    7.032  ns/op     0  B/op   0  allocs/op
-Benchmark_EqualFold_Short/10B/fiber-4                              258660369    4.686  ns/op     0  B/op   0  allocs/op
-Benchmark_EqualFold_Short/10B/default-4                            162186058    7.396  ns/op     0  B/op   0  allocs/op
-Benchmark_EqualFold_Short/16B/fiber-4                              189898923    6.270  ns/op     0  B/op   0  allocs/op
-Benchmark_EqualFold_Short/16B/default-4                             92492420    12.24  ns/op     0  B/op   0  allocs/op
-Benchmark_IndexControl/clean-16B/fiber-4                           203779250    5.889  ns/op     0  B/op   0  allocs/op
-Benchmark_IndexControl/clean-16B/fiber-except-tab-4                260252811    4.424  ns/op     0  B/op   0  allocs/op
-Benchmark_IndexControl/clean-16B/default-4                          55306483    21.98  ns/op     0  B/op   0  allocs/op
-Benchmark_IndexControl/clean-64B/fiber-4                           100000000    11.42  ns/op     0  B/op   0  allocs/op
-Benchmark_IndexControl/clean-64B/fiber-except-tab-4                 80312823    13.85  ns/op     0  B/op   0  allocs/op
-Benchmark_IndexControl/clean-64B/default-4                          10777072    109.7  ns/op     0  B/op   0  allocs/op
-Benchmark_IndexControl/ctl-at-end-64B/fiber-4                       84218676    13.88  ns/op     0  B/op   0  allocs/op
-Benchmark_IndexControl/ctl-at-end-64B/fiber-except-tab-4            82567161    14.24  ns/op     0  B/op   0  allocs/op
-Benchmark_IndexControl/ctl-at-end-64B/default-4                     12472396    93.10  ns/op     0  B/op   0  allocs/op
-Benchmark_CutByte/fiber-4                                          319360610    3.722  ns/op     0  B/op   0  allocs/op
-Benchmark_CutByte/default-4                                        186988519    6.394  ns/op     0  B/op   0  allocs/op
-Benchmark_CutByte/fiber-bytes-4                                    286163102    4.652  ns/op     0  B/op   0  allocs/op
-Benchmark_CutByte/default-bytes-4                                  248464538    4.805  ns/op     0  B/op   0  allocs/op
-Benchmark_LastCutByte/fiber-4                                      273541712    4.484  ns/op     0  B/op   0  allocs/op
-Benchmark_LastCutByte/default-4                                    306896436    3.697  ns/op     0  B/op   0  allocs/op
-Benchmark_AppendDuration/micros/fiber-4                             85459068    13.12  ns/op     0  B/op   0  allocs/op
-Benchmark_AppendDuration/micros/default-4                           51461097    22.68  ns/op     8  B/op   1  allocs/op
-Benchmark_AppendDuration/micros/fmt-4                               13520485    88.80  ns/op    16  B/op   2  allocs/op
-Benchmark_AppendDuration/millis-frac/fiber-4                        96734883    12.39  ns/op     0  B/op   0  allocs/op
-Benchmark_AppendDuration/millis-frac/default-4                      42376482    27.79  ns/op    16  B/op   1  allocs/op
-Benchmark_AppendDuration/millis-frac/fmt-4                          13255656    95.49  ns/op    24  B/op   2  allocs/op
-Benchmark_AppendDuration/hours/fiber-4                              56475243    20.75  ns/op     0  B/op   0  allocs/op
-Benchmark_AppendDuration/hours/default-4                            37045243    30.46  ns/op     8  B/op   1  allocs/op
-Benchmark_AppendDuration/hours/fmt-4                                12400474    91.18  ns/op    16  B/op   2  allocs/op
-Benchmark_FormatUint/small/fiber-4                                 930255656    1.226  ns/op     0  B/op   0  allocs/op
-Benchmark_FormatUint/small/strconv-4                               669114375    1.718  ns/op     0  B/op   0  allocs/op
-Benchmark_FormatUint/medium/fiber-4                                 53911075    19.20  ns/op    16  B/op   1  allocs/op
-Benchmark_FormatUint/medium/strconv-4                               44245470    25.03  ns/op    16  B/op   1  allocs/op
-Benchmark_FormatUint/large/fiber-4                                  43605513    26.27  ns/op    24  B/op   1  allocs/op
-Benchmark_FormatUint/large/strconv-4                                34594772    35.38  ns/op    24  B/op   1  allocs/op
-Benchmark_FormatInt/small_pos/fiber-4                              902787332    1.167  ns/op     0  B/op   0  allocs/op
-Benchmark_FormatInt/small_pos/strconv-4                            720079957    1.670  ns/op     0  B/op   0  allocs/op
-Benchmark_FormatInt/small_neg/fiber-4                              842577614    1.221  ns/op     0  B/op   0  allocs/op
-Benchmark_FormatInt/small_neg/strconv-4                             94182060    12.22  ns/op     3  B/op   1  allocs/op
-Benchmark_FormatInt/medium_pos/fiber-4                              69650205    19.84  ns/op    16  B/op   1  allocs/op
-Benchmark_FormatInt/medium_pos/strconv-4                            51092598    23.79  ns/op    16  B/op   1  allocs/op
-Benchmark_FormatInt/medium_neg/fiber-4                              54612351    20.42  ns/op    16  B/op   1  allocs/op
-Benchmark_FormatInt/medium_neg/strconv-4                            54855618    24.42  ns/op    16  B/op   1  allocs/op
-Benchmark_FormatInt/large_pos/fiber-4                               42541272    26.84  ns/op    24  B/op   1  allocs/op
-Benchmark_FormatInt/large_pos/strconv-4                             33527298    34.37  ns/op    24  B/op   1  allocs/op
-Benchmark_FormatInt/large_neg/fiber-4                               52515882    26.27  ns/op    24  B/op   1  allocs/op
-Benchmark_FormatInt/large_neg/strconv-4                             30426061    36.00  ns/op    24  B/op   1  allocs/op
-Benchmark_FormatUint32/fiber-4                                      58439538    18.89  ns/op    16  B/op   1  allocs/op
-Benchmark_FormatUint32/strconv-4                                    53144967    23.65  ns/op    16  B/op   1  allocs/op
-Benchmark_FormatInt32/fiber-4                                       52140723    20.59  ns/op    16  B/op   1  allocs/op
-Benchmark_FormatInt32/strconv-4                                     51030650    25.14  ns/op    16  B/op   1  allocs/op
-Benchmark_FormatUint16/fiber-4                                      90609734    13.73  ns/op     5  B/op   1  allocs/op
-Benchmark_FormatUint16/strconv-4                                    67957411    16.27  ns/op     5  B/op   1  allocs/op
-Benchmark_FormatInt16/fiber-4                                       70743320    14.80  ns/op     8  B/op   1  allocs/op
-Benchmark_FormatInt16/strconv-4                                     66420757    17.99  ns/op     8  B/op   1  allocs/op
-Benchmark_AppendUint/fiber-4                                       133488804    9.031  ns/op     0  B/op   0  allocs/op
-Benchmark_AppendUint/strconv-4                                      88840972    13.23  ns/op     0  B/op   0  allocs/op
-Benchmark_AppendInt/small_neg/fiber-4                              393770761    2.938  ns/op     0  B/op   0  allocs/op
-Benchmark_AppendInt/small_neg/strconv-4                            135034128    9.008  ns/op     0  B/op   0  allocs/op
-Benchmark_AppendInt/medium_neg/fiber-4                             128383106    9.430  ns/op     0  B/op   0  allocs/op
-Benchmark_AppendInt/medium_neg/strconv-4                            83808223    14.02  ns/op     0  B/op   0  allocs/op
-Benchmark_CanonicalHeaderKey/canonical/fiber-4                      63954270    19.20  ns/op     0  B/op   0  allocs/op
-Benchmark_CanonicalHeaderKey/canonical/default-4                    61848936    19.38  ns/op     0  B/op   0  allocs/op
-Benchmark_CanonicalHeaderKey/common-lower/fiber-4                   30324459    39.69  ns/op    16  B/op   1  allocs/op
-Benchmark_CanonicalHeaderKey/common-lower/default-4                 34708371    34.17  ns/op     0  B/op   0  allocs/op
-Benchmark_CanonicalHeaderKey/custom-lower/fiber-4                   20533173    57.36  ns/op    24  B/op   1  allocs/op
-Benchmark_CanonicalHeaderKey/custom-lower/default-4                 18845474    61.24  ns/op    24  B/op   1  allocs/op
-Benchmark_SplitHostPort/host-port/fiber-4                           96973551    13.53  ns/op     0  B/op   0  allocs/op
-Benchmark_SplitHostPort/host-port/default-4                        100000000    11.03  ns/op     0  B/op   0  allocs/op
-Benchmark_SplitHostPort/ipv6-port/fiber-4                           84532168    14.59  ns/op     0  B/op   0  allocs/op
-Benchmark_SplitHostPort/ipv6-port/default-4                         86026857    13.06  ns/op     0  B/op   0  allocs/op
-Benchmark_SplitHostPort/missing-port/fiber-4                       127113981    9.281  ns/op     0  B/op   0  allocs/op
-Benchmark_SplitHostPort/missing-port/default-4                      40466980    27.28  ns/op    32  B/op   1  allocs/op
-Benchmark_GetMIME/fiber-4                                           43632588    25.93  ns/op     0  B/op   0  allocs/op
-Benchmark_GetMIME/default-4                                         14095286    90.16  ns/op     0  B/op   0  allocs/op
-Benchmark_AppendHTTPDate/fiber-4                                    66145699    18.30  ns/op     0  B/op   0  allocs/op
-Benchmark_AppendHTTPDate/default-4                                  11478645    104.9  ns/op     0  B/op   0  allocs/op
-Benchmark_ParseHTTPDate/fiber-4                                     88654230    13.89  ns/op     0  B/op   0  allocs/op
-Benchmark_ParseHTTPDate/default-4                                    8176903    148.3  ns/op     0  B/op   0  allocs/op
-Benchmark_ParseIPv4/fiber-4                                         83364247    14.10  ns/op     0  B/op   0  allocs/op
-Benchmark_ParseIPv4/default-4                                       47784198    25.37  ns/op     0  B/op   0  allocs/op
-Benchmark_ParseIPv6/compressed/fiber-4                              32811793    38.84  ns/op     0  B/op   0  allocs/op
-Benchmark_ParseIPv6/compressed/default-4                            22000425    53.60  ns/op     0  B/op   0  allocs/op
-Benchmark_ParseIPv6/full/fiber-4                                    18724832    62.29  ns/op     0  B/op   0  allocs/op
-Benchmark_ParseIPv6/full/default-4                                  16512328    70.26  ns/op     0  B/op   0  allocs/op
-Benchmark_AppendJSONString/clean-16B/fiber-4                        73102746    15.95  ns/op     0  B/op   0  allocs/op
-Benchmark_AppendJSONString/clean-16B/default-4                      11879577    92.79  ns/op    40  B/op   2  allocs/op
-Benchmark_AppendJSONString/clean-64B/fiber-4                        32728236    35.51  ns/op     0  B/op   0  allocs/op
-Benchmark_AppendJSONString/clean-64B/default-4                       6469843    162.9  ns/op    96  B/op   2  allocs/op
-Benchmark_AppendJSONString/escaped-64B/fiber-4                       9077125    130.1  ns/op     0  B/op   0  allocs/op
-Benchmark_AppendJSONString/escaped-64B/default-4                     5625344    214.3  ns/op    96  B/op   2  allocs/op
-Benchmark_AppendJSONString/unicode-64B/fiber-4                       7455001    186.5  ns/op     0  B/op   0  allocs/op
-Benchmark_AppendJSONString/unicode-64B/default-4                     5769218    214.1  ns/op   112  B/op   2  allocs/op
-Benchmark_SplitTrimSeq/accept-encoding/fiber-4                      11107192    109.4  ns/op    80  B/op   4  allocs/op
-Benchmark_SplitTrimSeq/accept-encoding/default-4                    10212601    120.1  ns/op    96  B/op   4  allocs/op
-Benchmark_SplitTrimSeq/accept/fiber-4                                8430607    140.0  ns/op    80  B/op   4  allocs/op
-Benchmark_SplitTrimSeq/accept/default-4                              7539578    158.5  ns/op    96  B/op   4  allocs/op
-Benchmark_AppendQueryEscape/clean-64B/fiber-4                       31180040    38.02  ns/op     0  B/op   0  allocs/op
-Benchmark_AppendQueryEscape/clean-64B/default-4                      9700760    126.6  ns/op     0  B/op   0  allocs/op
-Benchmark_AppendQueryEscape/mixed-64B/fiber-4                        7308297    161.7  ns/op     0  B/op   0  allocs/op
-Benchmark_AppendQueryEscape/mixed-64B/default-4                      2573535    465.9  ns/op   192  B/op   2  allocs/op
-Benchmark_AppendQueryUnescape/plain-64B/fiber-4                    100000000    10.81  ns/op     0  B/op   0  allocs/op
-Benchmark_AppendQueryUnescape/plain-64B/default-4                   14994698    70.29  ns/op     0  B/op   0  allocs/op
-Benchmark_AppendQueryUnescape/escaped-64B/fiber-4                    8074832    148.0  ns/op     0  B/op   0  allocs/op
-Benchmark_AppendQueryUnescape/escaped-64B/default-4                  5591368    211.1  ns/op    48  B/op   1  allocs/op
-Benchmark_AppendPathUnescape/plain-25B/fiber-4                     151601898    7.852  ns/op     0  B/op   0  allocs/op
-Benchmark_AppendPathUnescape/plain-25B/default-4                    26725650    44.23  ns/op     0  B/op   0  allocs/op
-Benchmark_AppendPathUnescape/escaped-31B/fiber-4                    29934354    35.04  ns/op     0  B/op   0  allocs/op
-Benchmark_AppendPathUnescape/escaped-31B/default-4                  10363320    127.6  ns/op    24  B/op   1  allocs/op
+// go test -benchmem -run=^$ -count=1 . -bench='^Benchmark_(FormatUint|FormatInt|FormatUint32|FormatInt32|FormatUint16|FormatInt16|AppendUint|AppendInt|EqualFold_Short|GetMIME|AppendHTTPDate|ParseHTTPDate|AppendDuration|AppendQueryEscape|AppendQueryUnescape|AppendPathUnescape|AppendJSONString|ParseIPv4|ParseIPv6|CanonicalHeaderKey|IndexControl|CutByte|LastCutByte|SplitHostPort|SplitTrimSeq)$'
+Benchmark_EqualFold_Short/3B/fiber-4                               229602248    5.312  ns/op     0  B/op   0  allocs/op
+Benchmark_EqualFold_Short/3B/default-4                             204528979    5.852  ns/op     0  B/op   0  allocs/op
+Benchmark_EqualFold_Short/4B/fiber-4                               229813917    5.255  ns/op     0  B/op   0  allocs/op
+Benchmark_EqualFold_Short/4B/default-4                             156456847    7.464  ns/op     0  B/op   0  allocs/op
+Benchmark_EqualFold_Short/5B/fiber-4                               229097964    5.234  ns/op     0  B/op   0  allocs/op
+Benchmark_EqualFold_Short/5B/default-4                             197214793    6.189  ns/op     0  B/op   0  allocs/op
+Benchmark_EqualFold_Short/7B/fiber-4                               232463892    5.179  ns/op     0  B/op   0  allocs/op
+Benchmark_EqualFold_Short/7B/default-4                             160397131    7.450  ns/op     0  B/op   0  allocs/op
+Benchmark_EqualFold_Short/8B/fiber-4                               216077086    5.531  ns/op     0  B/op   0  allocs/op
+Benchmark_EqualFold_Short/8B/default-4                             159104245    7.543  ns/op     0  B/op   0  allocs/op
+Benchmark_EqualFold_Short/10B/fiber-4                              144306822    8.317  ns/op     0  B/op   0  allocs/op
+Benchmark_EqualFold_Short/10B/default-4                            120878482    9.925  ns/op     0  B/op   0  allocs/op
+Benchmark_EqualFold_Short/16B/fiber-4                              143038372    8.357  ns/op     0  B/op   0  allocs/op
+Benchmark_EqualFold_Short/16B/default-4                             85405070    14.49  ns/op     0  B/op   0  allocs/op
+Benchmark_IndexControl/clean-16B/fiber-4                           169144147    7.146  ns/op     0  B/op   0  allocs/op
+Benchmark_IndexControl/clean-16B/fiber-except-tab-4                167529128    7.135  ns/op     0  B/op   0  allocs/op
+Benchmark_IndexControl/clean-16B/default-4                          32870788    36.35  ns/op     0  B/op   0  allocs/op
+Benchmark_IndexControl/clean-64B/fiber-4                            75379568    16.27  ns/op     0  B/op   0  allocs/op
+Benchmark_IndexControl/clean-64B/fiber-except-tab-4                 73955293    16.14  ns/op     0  B/op   0  allocs/op
+Benchmark_IndexControl/clean-64B/default-4                           8875356    135.6  ns/op     0  B/op   0  allocs/op
+Benchmark_IndexControl/ctl-at-end-64B/fiber-4                       72450939    16.83  ns/op     0  B/op   0  allocs/op
+Benchmark_IndexControl/ctl-at-end-64B/fiber-except-tab-4            71671362    16.68  ns/op     0  B/op   0  allocs/op
+Benchmark_IndexControl/ctl-at-end-64B/default-4                      8478050    141.1  ns/op     0  B/op   0  allocs/op
+Benchmark_CutByte/fiber-4                                          180741241    6.688  ns/op     0  B/op   0  allocs/op
+Benchmark_CutByte/default-4                                        100000000    10.28  ns/op     0  B/op   0  allocs/op
+Benchmark_CutByte/fiber-bytes-4                                    168499478    7.147  ns/op     0  B/op   0  allocs/op
+Benchmark_CutByte/default-bytes-4                                  141645026    8.407  ns/op     0  B/op   0  allocs/op
+Benchmark_LastCutByte/fiber-4                                      190695121    6.336  ns/op     0  B/op   0  allocs/op
+Benchmark_LastCutByte/default-4                                    201893814    5.937  ns/op     0  B/op   0  allocs/op
+Benchmark_AppendDuration/micros/fiber-4                             94853876    12.96  ns/op     0  B/op   0  allocs/op
+Benchmark_AppendDuration/micros/default-4                           37404410    30.76  ns/op     8  B/op   1  allocs/op
+Benchmark_AppendDuration/micros/fmt-4                                9448436    127.8  ns/op    16  B/op   2  allocs/op
+Benchmark_AppendDuration/millis-frac/fiber-4                        57206034    20.25  ns/op     0  B/op   0  allocs/op
+Benchmark_AppendDuration/millis-frac/default-4                      28241080    39.08  ns/op    16  B/op   1  allocs/op
+Benchmark_AppendDuration/millis-frac/fmt-4                           8029897    144.3  ns/op    24  B/op   2  allocs/op
+Benchmark_AppendDuration/hours/fiber-4                              77311298    15.06  ns/op     0  B/op   0  allocs/op
+Benchmark_AppendDuration/hours/default-4                            26855806    42.60  ns/op     8  B/op   1  allocs/op
+Benchmark_AppendDuration/hours/fmt-4                                 8546384    146.6  ns/op    16  B/op   2  allocs/op
+Benchmark_FormatUint/small/fiber-4                                 629069014    1.888  ns/op     0  B/op   0  allocs/op
+Benchmark_FormatUint/small/strconv-4                               505295925    2.371  ns/op     0  B/op   0  allocs/op
+Benchmark_FormatUint/medium/fiber-4                                 40310542    28.33  ns/op    16  B/op   1  allocs/op
+Benchmark_FormatUint/medium/strconv-4                               36065356    33.07  ns/op    16  B/op   1  allocs/op
+Benchmark_FormatUint/large/fiber-4                                  36428881    33.66  ns/op    24  B/op   1  allocs/op
+Benchmark_FormatUint/large/strconv-4                                24582408    49.04  ns/op    24  B/op   1  allocs/op
+Benchmark_FormatInt/small_pos/fiber-4                              568438807    2.074  ns/op     0  B/op   0  allocs/op
+Benchmark_FormatInt/small_pos/strconv-4                            509641584    2.378  ns/op     0  B/op   0  allocs/op
+Benchmark_FormatInt/small_neg/fiber-4                              552536096    2.169  ns/op     0  B/op   0  allocs/op
+Benchmark_FormatInt/small_neg/strconv-4                             67741922    18.14  ns/op     3  B/op   1  allocs/op
+Benchmark_FormatInt/medium_pos/fiber-4                              36409581    28.36  ns/op    16  B/op   1  allocs/op
+Benchmark_FormatInt/medium_pos/strconv-4                            34719836    34.57  ns/op    16  B/op   1  allocs/op
+Benchmark_FormatInt/medium_neg/fiber-4                              43244299    27.74  ns/op    16  B/op   1  allocs/op
+Benchmark_FormatInt/medium_neg/strconv-4                            36308307    33.28  ns/op    16  B/op   1  allocs/op
+Benchmark_FormatInt/large_pos/fiber-4                               34108224    34.78  ns/op    24  B/op   1  allocs/op
+Benchmark_FormatInt/large_pos/strconv-4                             23271465    49.00  ns/op    24  B/op   1  allocs/op
+Benchmark_FormatInt/large_neg/fiber-4                               35237299    34.85  ns/op    24  B/op   1  allocs/op
+Benchmark_FormatInt/large_neg/strconv-4                             24433351    47.63  ns/op    24  B/op   1  allocs/op
+Benchmark_FormatUint32/fiber-4                                      46063810    26.37  ns/op    16  B/op   1  allocs/op
+Benchmark_FormatUint32/strconv-4                                    34846262    33.88  ns/op    16  B/op   1  allocs/op
+Benchmark_FormatInt32/fiber-4                                       42975921    27.59  ns/op    16  B/op   1  allocs/op
+Benchmark_FormatInt32/strconv-4                                     36954268    33.17  ns/op    16  B/op   1  allocs/op
+Benchmark_FormatUint16/fiber-4                                      60632233    19.36  ns/op     5  B/op   1  allocs/op
+Benchmark_FormatUint16/strconv-4                                    51189382    22.75  ns/op     5  B/op   1  allocs/op
+Benchmark_FormatInt16/fiber-4                                       55760065    20.90  ns/op     8  B/op   1  allocs/op
+Benchmark_FormatInt16/strconv-4                                     48868172    24.20  ns/op     8  B/op   1  allocs/op
+Benchmark_AppendUint/fiber-4                                        91578640    12.35  ns/op     0  B/op   0  allocs/op
+Benchmark_AppendUint/strconv-4                                      72172658    17.55  ns/op     0  B/op   0  allocs/op
+Benchmark_AppendInt/small_neg/fiber-4                              314797556    3.782  ns/op     0  B/op   0  allocs/op
+Benchmark_AppendInt/small_neg/strconv-4                            100000000    10.91  ns/op     0  B/op   0  allocs/op
+Benchmark_AppendInt/medium_neg/fiber-4                              91859277    13.20  ns/op     0  B/op   0  allocs/op
+Benchmark_AppendInt/medium_neg/strconv-4                            70492820    17.12  ns/op     0  B/op   0  allocs/op
+Benchmark_CanonicalHeaderKey/canonical/fiber-4                      66962880    17.98  ns/op     0  B/op   0  allocs/op
+Benchmark_CanonicalHeaderKey/canonical/default-4                    46076755    26.65  ns/op     0  B/op   0  allocs/op
+Benchmark_CanonicalHeaderKey/common-lower/fiber-4                   28066642    44.43  ns/op    16  B/op   1  allocs/op
+Benchmark_CanonicalHeaderKey/common-lower/default-4                 23367423    50.83  ns/op     0  B/op   0  allocs/op
+Benchmark_CanonicalHeaderKey/custom-lower/fiber-4                   20437851    58.07  ns/op    24  B/op   1  allocs/op
+Benchmark_CanonicalHeaderKey/custom-lower/default-4                 13395525    87.34  ns/op    24  B/op   1  allocs/op
+Benchmark_SplitHostPort/host-port/fiber-4                           66885448    17.17  ns/op     0  B/op   0  allocs/op
+Benchmark_SplitHostPort/host-port/default-4                         73398602    16.60  ns/op     0  B/op   0  allocs/op
+Benchmark_SplitHostPort/ipv6-port/fiber-4                           69142788    17.70  ns/op     0  B/op   0  allocs/op
+Benchmark_SplitHostPort/ipv6-port/default-4                         68252304    17.28  ns/op     0  B/op   0  allocs/op
+Benchmark_SplitHostPort/missing-port/fiber-4                       167778152    7.224  ns/op     0  B/op   0  allocs/op
+Benchmark_SplitHostPort/missing-port/default-4                      30424182    38.16  ns/op    32  B/op   1  allocs/op
+Benchmark_GetMIME/fiber-4                                           39471765    29.38  ns/op     0  B/op   0  allocs/op
+Benchmark_GetMIME/default-4                                         10284040    112.3  ns/op     0  B/op   0  allocs/op
+Benchmark_AppendHTTPDate/fiber-4                                    47681026    25.21  ns/op     0  B/op   0  allocs/op
+Benchmark_AppendHTTPDate/default-4                                   8757169    134.9  ns/op     0  B/op   0  allocs/op
+Benchmark_ParseHTTPDate/fiber-4                                     58871844    18.57  ns/op     0  B/op   0  allocs/op
+Benchmark_ParseHTTPDate/default-4                                    6421057    187.1  ns/op     0  B/op   0  allocs/op
+Benchmark_ParseIPv4/fiber-4                                         66056898    18.34  ns/op     0  B/op   0  allocs/op
+Benchmark_ParseIPv4/default-4                                       44932904    26.84  ns/op     0  B/op   0  allocs/op
+Benchmark_ParseIPv6/compressed/fiber-4                              25820896    46.48  ns/op     0  B/op   0  allocs/op
+Benchmark_ParseIPv6/compressed/default-4                            17371059    65.48  ns/op     0  B/op   0  allocs/op
+Benchmark_ParseIPv6/full/fiber-4                                    20636487    60.00  ns/op     0  B/op   0  allocs/op
+Benchmark_ParseIPv6/full/default-4                                  12097987    84.13  ns/op     0  B/op   0  allocs/op
+Benchmark_AppendJSONString/clean-16B/fiber-4                        57606924    21.13  ns/op     0  B/op   0  allocs/op
+Benchmark_AppendJSONString/clean-16B/default-4                       8575510    143.9  ns/op    40  B/op   2  allocs/op
+Benchmark_AppendJSONString/clean-64B/fiber-4                        20014062    60.74  ns/op     0  B/op   0  allocs/op
+Benchmark_AppendJSONString/clean-64B/default-4                       5525064    222.1  ns/op    96  B/op   2  allocs/op
+Benchmark_AppendJSONString/escaped-64B/fiber-4                       7843610    149.5  ns/op     0  B/op   0  allocs/op
+Benchmark_AppendJSONString/escaped-64B/default-4                     4009515    291.9  ns/op    96  B/op   2  allocs/op
+Benchmark_AppendJSONString/unicode-64B/fiber-4                       4916204    239.6  ns/op     0  B/op   0  allocs/op
+Benchmark_AppendJSONString/unicode-64B/default-4                     3485493    347.0  ns/op   112  B/op   2  allocs/op
+Benchmark_SplitTrimSeq/accept-encoding/fiber-4                      54431074    21.50  ns/op     0  B/op   0  allocs/op
+Benchmark_SplitTrimSeq/accept-encoding/default-4                    50593407    24.16  ns/op     0  B/op   0  allocs/op
+Benchmark_SplitTrimSeq/accept/fiber-4                               19936736    59.24  ns/op     0  B/op   0  allocs/op
+Benchmark_SplitTrimSeq/accept/default-4                             18168722    65.87  ns/op     0  B/op   0  allocs/op
+Benchmark_AppendQueryEscape/clean-64B/fiber-4                       25016198    49.70  ns/op     0  B/op   0  allocs/op
+Benchmark_AppendQueryEscape/clean-64B/default-4                      6857455    176.6  ns/op     0  B/op   0  allocs/op
+Benchmark_AppendQueryEscape/mixed-64B/fiber-4                        5858684    213.5  ns/op     0  B/op   0  allocs/op
+Benchmark_AppendQueryEscape/mixed-64B/default-4                      1989934    600.0  ns/op   192  B/op   2  allocs/op
+Benchmark_AppendQueryUnescape/plain-64B/fiber-4                     76538192    15.30  ns/op     0  B/op   0  allocs/op
+Benchmark_AppendQueryUnescape/plain-64B/default-4                   10383134    116.5  ns/op     0  B/op   0  allocs/op
+Benchmark_AppendQueryUnescape/escaped-64B/fiber-4                    4906606    218.5  ns/op     0  B/op   0  allocs/op
+Benchmark_AppendQueryUnescape/escaped-64B/default-4                  4306238    274.6  ns/op    48  B/op   1  allocs/op
+Benchmark_AppendPathUnescape/plain-25B/fiber-4                     100000000    12.00  ns/op     0  B/op   0  allocs/op
+Benchmark_AppendPathUnescape/plain-25B/default-4                    24661267    45.81  ns/op     0  B/op   0  allocs/op
+Benchmark_AppendPathUnescape/escaped-31B/fiber-4                    20543667    58.60  ns/op     0  B/op   0  allocs/op
+Benchmark_AppendPathUnescape/escaped-31B/default-4                   8119328    147.5  ns/op    24  B/op   1  allocs/op
 ```
 
 ## SWAR primitives

--- a/ascii.go
+++ b/ascii.go
@@ -6,10 +6,11 @@ import (
 	"github.com/gofiber/utils/v2/swar"
 )
 
-// quoteLanes and backslashLanes broadcast '"' and '\\' to every lane.
+// quoteLanes, backslashLanes, and tabLanes broadcast '"', '\\', and HTAB to every lane.
 const (
 	quoteLanes     = uint64('"') * swar.Ones
 	backslashLanes = uint64('\\') * swar.Ones
+	tabLanes       = uint64('\t') * swar.Ones
 )
 
 // The dispatch prologues below gate on simd.MinLen — the measured length
@@ -123,16 +124,9 @@ func IndexNonQuotable[S byteSeq](s S) int {
 }
 
 // nonQuotableMask marks the lanes of w holding bytes that need RFC 9110
-// quoted-string escaping. Like swar.ZeroLanes, the result is exact in and below
-// the first marked lane, which is all the first-match scan above consumes.
+// quoted-string escaping: controls other than HTAB (quotable qdtext), DEL,
+// '"', and '\\'. Like swar.ZeroLanes, the result is exact in and below the
+// first marked lane, which is all the first-match scan above consumes.
 func nonQuotableMask(w uint64) uint64 {
-	// Controls (< 0x20) and DEL (0x7F) share one biased range test:
-	// t := ((c & 0x7F) + 1) & 0x7F maps DEL to 0 and controls to 0x01..0x20,
-	// so t <= 0x20 captures exactly both; lanes with the high bit set
-	// (obs-text, always quotable) are excluded by the &^ w term. HTAB is
-	// quotable qdtext, so its lanes are cleared with an exact match mask —
-	// an approximate one could wrongly clear a control lane above a tab.
-	t := ((w & swar.LowSeven) + swar.Ones) & swar.LowSeven
-	ctl := ^(t + (0x80-0x21)*swar.Ones) &^ w & swar.HighBits &^ swar.MatchByteMask(w, '\t')
-	return ctl | swar.ZeroLanes(w^quoteLanes) | swar.ZeroLanes(w^backslashLanes)
+	return controlLanes(w)&otherLanes(w, tabLanes) | swar.ZeroLanes(w^quoteLanes) | swar.ZeroLanes(w^backslashLanes)
 }

--- a/byteseq_test.go
+++ b/byteseq_test.go
@@ -475,9 +475,9 @@ func Test_EqualFold_Lengths(t *testing.T) {
 				if c == a[i] {
 					continue
 				}
-				mutated := append([]byte{}, flipped...)
+				mutated := bytes.Clone(flipped)
 				mutated[i] = c
-				want := strings.EqualFold(a, string(mutated))
+				want := asciiFoldUpper(a) == asciiFoldUpper(string(mutated))
 				require.Equal(t, want, EqualFold(a, string(mutated)), "len %d pos %d byte %#x", n, i, c)
 				require.Equal(t, want, EqualFold([]byte(a), mutated), "len %d pos %d byte %#x", n, i, c)
 			}

--- a/control.go
+++ b/control.go
@@ -20,32 +20,42 @@ func IndexControlExceptTab[S byteSeq](s S) int {
 	return scanControl(s, '\t')
 }
 
-// scanControl is the word scan behind both, with exempt masked out per word.
+// scanControl is the word scan behind both. Words holding no control byte,
+// the common case, skip the exemption test entirely.
 func scanControl[S byteSeq](s S, exempt byte) int {
 	n := len(s)
+	exemptLanes := swar.Broadcast(exempt)
 	i := 0
 	for ; i+16 <= n; i += 16 {
 		w := s[i : i+16]
-		m0 := controlLanes(swar.Load8(w, 0), exempt)
-		m1 := controlLanes(swar.Load8(w, 8), exempt)
+		w0, w1 := swar.Load8(w, 0), swar.Load8(w, 8)
+		m0, m1 := controlLanes(w0), controlLanes(w1)
 		if m0|m1 != 0 {
-			if m0 != 0 {
+			if m0 &= otherLanes(w0, exemptLanes); m0 != 0 {
 				return i + swar.FirstLane(m0)
 			}
-			return i + 8 + swar.FirstLane(m1)
+			if m1 &= otherLanes(w1, exemptLanes); m1 != 0 {
+				return i + 8 + swar.FirstLane(m1)
+			}
 		}
 	}
 	for ; i+8 <= n; i += 8 {
-		if m := controlLanes(swar.Load8(s, i), exempt); m != 0 {
-			return i + swar.FirstLane(m)
+		w := swar.Load8(s, i)
+		if m := controlLanes(w); m != 0 {
+			if m &= otherLanes(w, exemptLanes); m != 0 {
+				return i + swar.FirstLane(m)
+			}
 		}
 	}
 	if i == n {
 		return -1
 	}
 	if n >= 8 {
-		if m := controlLanes(swar.Load8(s, n-8), exempt); m != 0 {
-			return n - 8 + swar.FirstLane(m)
+		w := swar.Load8(s, n-8)
+		if m := controlLanes(w); m != 0 {
+			if m &= otherLanes(w, exemptLanes); m != 0 {
+				return n - 8 + swar.FirstLane(m)
+			}
 		}
 		return -1
 	}
@@ -57,10 +67,17 @@ func scanControl[S byteSeq](s S, exempt byte) int {
 	return -1
 }
 
-// controlLanes flags the lanes of w below 0x20 or equal to DEL, other than
-// exempt, exactly per lane; the biased lanes stay below 0xE0, so no carries.
-func controlLanes(w uint64, exempt byte) uint64 {
+// controlLanes flags the lanes of w below 0x20 or equal to DEL, exactly per
+// lane; the biased lanes stay below 0xE0, so no carries.
+func controlLanes(w uint64) uint64 {
 	b := w & swar.LowSeven
-	ctl := (^(b + (0x80-0x20)*swar.Ones) | (b + swar.Ones)) &^ w & swar.HighBits
-	return ctl &^ swar.MatchByteMask(w, exempt)
+	return (^(b + (0x80-0x20)*swar.Ones) | (b + swar.Ones)) &^ w & swar.HighBits
+}
+
+// otherLanes flags the lanes of w that differ from the byte broadcast in
+// lanes, exactly per lane: x is zero only in the equal lanes, and only there
+// is the high bit of ((x | HighBits) - Ones) | x clear (swar.MatchByteMask's test).
+func otherLanes(w, lanes uint64) uint64 {
+	x := w ^ lanes
+	return ((x | swar.HighBits) - swar.Ones) | x
 }

--- a/control_test.go
+++ b/control_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"slices"
 	"strings"
 	"testing"
 	"unicode"
@@ -19,25 +20,26 @@ func refIndexControl(s string, exempt byte) int {
 	return -1
 }
 
+// checkIndexControl compares both scanners on both input types with the reference.
+func checkIndexControl(tb testing.TB, s string) {
+	tb.Helper()
+	if want := refIndexControl(s, noControlExemption); IndexControl(s) != want || IndexControl([]byte(s)) != want {
+		tb.Fatalf("IndexControl(%q) = %d/%d, want %d", s, IndexControl(s), IndexControl([]byte(s)), want)
+	}
+	if want := refIndexControl(s, '\t'); IndexControlExceptTab(s) != want || IndexControlExceptTab([]byte(s)) != want {
+		tb.Fatalf("IndexControlExceptTab(%q) = %d/%d, want %d", s, IndexControlExceptTab(s), IndexControlExceptTab([]byte(s)), want)
+	}
+}
+
 func Test_IndexControl(t *testing.T) {
 	t.Parallel()
-	check := func(s string) {
-		t.Helper()
-		require.Equal(t, refIndexControl(s, noControlExemption), IndexControl(s), "IndexControl(%q)", s)
-		require.Equal(t, refIndexControl(s, noControlExemption), IndexControl([]byte(s)), "IndexControl(%q) bytes", s)
-		require.Equal(t, refIndexControl(s, '\t'), IndexControlExceptTab(s), "IndexControlExceptTab(%q)", s)
-		require.Equal(t, refIndexControl(s, '\t'), IndexControlExceptTab([]byte(s)), "IndexControlExceptTab(%q) bytes", s)
-	}
-
 	// Every byte value at every position of clean prefixes up to 40 bytes, so each scan shape sees each byte.
 	clean := strings.Repeat("abcdefghijklmnopqrstuvwxyz0123456789", 2)
 	for n := 0; n <= 40; n++ {
-		check(clean[:n])
+		checkIndexControl(t, clean[:n])
 		for c := range 256 {
-			buf := []byte(clean[:n])
 			for pos := 0; pos <= n; pos++ {
-				b := append(append(append([]byte{}, buf[:pos]...), byte(c)), buf[pos:]...)
-				check(string(b))
+				checkIndexControl(t, string(slices.Insert([]byte(clean[:n]), pos, byte(c))))
 			}
 		}
 	}
@@ -64,10 +66,7 @@ func FuzzIndexControl(f *testing.F) {
 	f.Add("utf8 caf\xc3\xa9 and \xc2\x85")
 	f.Add(strings.Repeat("x", 31) + "\x01")
 	f.Fuzz(func(t *testing.T, s string) {
-		require.Equal(t, refIndexControl(s, noControlExemption), IndexControl(s))
-		require.Equal(t, refIndexControl(s, noControlExemption), IndexControl([]byte(s)))
-		require.Equal(t, refIndexControl(s, '\t'), IndexControlExceptTab(s))
-		require.Equal(t, refIndexControl(s, '\t'), IndexControlExceptTab([]byte(s)))
+		checkIndexControl(t, s)
 	})
 }
 

--- a/duration.go
+++ b/duration.go
@@ -23,35 +23,33 @@ func durationToBuf(buf *[durationBufLen]byte, d time.Duration) int {
 		u = -u
 	}
 
+	w--
+	buf[w] = 's'
 	if u < uint64(time.Second) {
-		// Sub-second: ns, µs (two UTF-8 bytes), or ms.
-		var prec int
-		w--
-		buf[w] = 's'
+		// Sub-second: ns, µs (two UTF-8 bytes), or ms. The unit splits are
+		// constant divisions, which compile to multiplies.
 		w--
 		switch {
 		case u == 0:
 			buf[w] = '0'
 			return w
 		case u < uint64(time.Microsecond):
-			prec = 0
 			buf[w] = 'n'
 		case u < uint64(time.Millisecond):
-			prec = 3
 			w--
 			buf[w] = 0xC2 // "µ" is 0xC2 0xB5
 			buf[w+1] = 0xB5
+			w = durationFrac(buf, w, u%uint64(time.Microsecond), 3)
+			u /= uint64(time.Microsecond)
 		default:
-			prec = 6
 			buf[w] = 'm'
+			w = durationFrac(buf, w, u%uint64(time.Millisecond), 6)
+			u /= uint64(time.Millisecond)
 		}
-		w, u = durationFrac(buf, w, u, prec)
 		w = durationInt(buf, w, u)
 	} else {
-		w--
-		buf[w] = 's'
-		w, u = durationFrac(buf, w, u, 9)
-		// u is now whole seconds.
+		w = durationFrac(buf, w, u%uint64(time.Second), 9)
+		u /= uint64(time.Second)
 		w = durationInt(buf, w, u%60)
 		u /= 60
 		if u > 0 {
@@ -74,40 +72,47 @@ func durationToBuf(buf *[durationBufLen]byte, d time.Duration) int {
 	return w
 }
 
-// durationFrac writes v/10**prec's fraction ending at buf[w] without trailing
-// zeros and returns the new offset with v/10**prec.
-func durationFrac(buf *[durationBufLen]byte, w int, v uint64, prec int) (int, uint64) {
-	started := false
-	for range prec {
-		digit := v % 10
-		v /= 10
-		started = started || digit != 0
-		if started {
-			w--
-			buf[w] = byte(digit) + '0'
-		}
+// durationFrac writes the prec-digit fraction frac ending at buf[w] without
+// its trailing zeros (nothing at all when it is zero, the common case) and
+// returns the new offset.
+func durationFrac(buf *[durationBufLen]byte, w int, frac uint64, prec int) int {
+	if frac == 0 {
+		return w
 	}
-	if started {
+	for frac%1000 == 0 {
+		frac /= 1000
+		prec -= 3
+	}
+	for frac%10 == 0 {
+		frac /= 10
+		prec--
+	}
+	for ; prec >= 2; prec -= 2 {
+		q := frac / 100
+		w -= 2
+		putPair(buf[:], w, frac-q*100)
+		frac = q
+	}
+	if prec == 1 {
 		w--
-		buf[w] = '.'
+		buf[w] = byte(frac) + '0'
 	}
-	return w, v
+	w--
+	buf[w] = '.'
+	return w
 }
 
 // durationInt writes the digits of v ending at buf[w] and returns the new offset.
 func durationInt(buf *[durationBufLen]byte, w int, v uint64) int {
 	for v >= 100 {
 		q := v / 100
-		r := v - q*100
 		w -= 2
-		buf[w] = decimalPairs[2*r]
-		buf[w+1] = decimalPairs[2*r+1]
+		putPair(buf[:], w, v-q*100)
 		v = q
 	}
 	if v >= 10 {
 		w -= 2
-		buf[w] = decimalPairs[2*v]
-		buf[w+1] = decimalPairs[2*v+1]
+		putPair(buf[:], w, v)
 		return w
 	}
 	w--

--- a/duration_test.go
+++ b/duration_test.go
@@ -3,10 +3,9 @@ package utils
 import (
 	"fmt"
 	"math"
+	"math/rand"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/require"
 )
 
 func Test_AppendDuration(t *testing.T) {
@@ -14,8 +13,12 @@ func Test_AppendDuration(t *testing.T) {
 	check := func(d time.Duration) {
 		t.Helper()
 		want := d.String()
-		require.Equal(t, want, string(AppendDuration(nil, d)), "AppendDuration(%d)", int64(d))
-		require.Equal(t, "x"+want, string(AppendDuration([]byte("x"), d)), "AppendDuration(%d) with prefix", int64(d))
+		if got := string(AppendDuration(nil, d)); got != want {
+			t.Fatalf("AppendDuration(%d) = %q, want %q", int64(d), got, want)
+		}
+		if got := string(AppendDuration([]byte("x"), d)); got != "x"+want {
+			t.Fatalf("AppendDuration(%d) with prefix = %q, want %q", int64(d), got, "x"+want)
+		}
 	}
 
 	// Every unit boundary, the values just around it, and the extremes.
@@ -48,11 +51,9 @@ func Test_AppendDuration(t *testing.T) {
 		check(-d)
 	}
 	// A deterministic pseudo-random spread across every magnitude.
-	x := uint64(0x9E3779B97F4A7C15)
+	rng := rand.New(rand.NewSource(1)) //nolint:gosec // deterministic test data
 	for range 200000 {
-		x ^= x << 13
-		x ^= x >> 7
-		x ^= x << 17
+		x := rng.Uint64()
 		check(time.Duration(x >> (x % 64)))
 		check(-time.Duration(x >> (x % 64)))
 	}

--- a/format.go
+++ b/format.go
@@ -59,7 +59,7 @@ const decimalPairs = "0001020304050607080910111213141516171819202122232425262728
 // eight zero-padded digit lanes (most significant first) with lane-parallel
 // divisions, and leading zeros are zero lanes found by a trailing-zero count.
 const (
-	asciiZeros   = 0x3030303030303030 // '0' in every lane; digits are below 16, so OR equals add
+	digitZeros   = 0x3030303030303030 // '0' in every lane; digit lanes are below 16, so OR equals add
 	digitsBufLen = 24                 // three lane groups; 20 digits plus a sign fit
 	digitsGroup  = 100000000          // value of one lane group
 )
@@ -80,20 +80,20 @@ func digits8(n uint32) uint64 {
 func uintToBuf(buf *[digitsBufLen]byte, n uint64) int {
 	if n < digitsGroup {
 		z := digits8(uint32(n))
-		binary.LittleEndian.PutUint64(buf[16:24], z|asciiZeros)
+		binary.LittleEndian.PutUint64(buf[16:24], z|digitZeros)
 		return 16 + bits.TrailingZeros64(z)>>3
 	}
 	hi := n / digitsGroup
-	binary.LittleEndian.PutUint64(buf[16:24], digits8(uint32(n-hi*digitsGroup))|asciiZeros)
+	binary.LittleEndian.PutUint64(buf[16:24], digits8(uint32(n-hi*digitsGroup))|digitZeros)
 	if hi < digitsGroup {
 		z := digits8(uint32(hi))
-		binary.LittleEndian.PutUint64(buf[8:16], z|asciiZeros)
+		binary.LittleEndian.PutUint64(buf[8:16], z|digitZeros)
 		return 8 + bits.TrailingZeros64(z)>>3
 	}
 	top := uint32(hi / digitsGroup) // at most 1844
-	binary.LittleEndian.PutUint64(buf[8:16], digits8(uint32(hi-uint64(top)*digitsGroup))|asciiZeros)
+	binary.LittleEndian.PutUint64(buf[8:16], digits8(uint32(hi-uint64(top)*digitsGroup))|digitZeros)
 	z := digits8(top)
-	binary.LittleEndian.PutUint64(buf[0:8], z|asciiZeros)
+	binary.LittleEndian.PutUint64(buf[0:8], z|digitZeros)
 	return bits.TrailingZeros64(z) >> 3
 }
 
@@ -101,13 +101,13 @@ func uintToBuf(buf *[digitsBufLen]byte, n uint64) int {
 func uint32ToBuf(buf *[16]byte, n uint32) int {
 	if n < digitsGroup {
 		z := digits8(n)
-		binary.LittleEndian.PutUint64(buf[8:16], z|asciiZeros)
+		binary.LittleEndian.PutUint64(buf[8:16], z|digitZeros)
 		return 8 + bits.TrailingZeros64(z)>>3
 	}
 	hi := n / digitsGroup // at most 42
-	binary.LittleEndian.PutUint64(buf[8:16], digits8(n-hi*digitsGroup)|asciiZeros)
+	binary.LittleEndian.PutUint64(buf[8:16], digits8(n-hi*digitsGroup)|digitZeros)
 	z := digits8(hi)
-	binary.LittleEndian.PutUint64(buf[0:8], z|asciiZeros)
+	binary.LittleEndian.PutUint64(buf[0:8], z|digitZeros)
 	return bits.TrailingZeros64(z) >> 3
 }
 

--- a/format_test.go
+++ b/format_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"math"
+	"math/rand"
 	"strconv"
 	"testing"
 
@@ -372,32 +373,40 @@ func Test_UintDigits_IntDigits(t *testing.T) {
 // Test_Format_Sweep pins the formatters to strconv over a dense sweep, every decimal and group boundary, and a random spread.
 func Test_Format_Sweep(t *testing.T) {
 	t.Parallel()
+	// The sweep runs hundreds of thousands of values, so it compares directly instead of through require.
+	eq := func(name, got, want string) {
+		t.Helper()
+		if got != want {
+			t.Fatalf("%s: got %q, want %q", name, got, want)
+		}
+	}
 	check := func(n uint64) {
 		t.Helper()
 		want := strconv.FormatUint(n, 10)
-		require.Equal(t, want, FormatUint(n), "FormatUint(%d)", n)
-		require.Equal(t, want, string(AppendUint([]byte("x"), n))[1:], "AppendUint(%d)", n)
+		eq("FormatUint", FormatUint(n), want)
+		eq("AppendUint", string(AppendUint([]byte("x"), n))[1:], want)
 		if n <= math.MaxUint32 {
-			require.Equal(t, want, FormatUint32(uint32(n)), "FormatUint32(%d)", n)
+			eq("FormatUint32", FormatUint32(uint32(n)), want)
 		}
 		if n <= math.MaxUint16 {
-			require.Equal(t, want, FormatUint16(uint16(n)), "FormatUint16(%d)", n)
+			eq("FormatUint16", FormatUint16(uint16(n)), want)
 		}
 		if n <= math.MaxInt64 {
 			i := int64(n)
-			require.Equal(t, strconv.FormatInt(i, 10), FormatInt(i), "FormatInt(%d)", i)
-			require.Equal(t, strconv.FormatInt(-i, 10), FormatInt(-i), "FormatInt(%d)", -i)
-			require.Equal(t, strconv.FormatInt(-i, 10), string(AppendInt([]byte("x"), -i))[1:], "AppendInt(%d)", -i)
+			neg := strconv.FormatInt(-i, 10)
+			eq("FormatInt", FormatInt(i), want)
+			eq("FormatInt", FormatInt(-i), neg)
+			eq("AppendInt", string(AppendInt([]byte("x"), -i))[1:], neg)
 		}
 		if n <= math.MaxInt32 {
 			i := int32(n)
-			require.Equal(t, strconv.FormatInt(int64(i), 10), FormatInt32(i), "FormatInt32(%d)", i)
-			require.Equal(t, strconv.FormatInt(int64(-i), 10), FormatInt32(-i), "FormatInt32(%d)", -i)
+			eq("FormatInt32", FormatInt32(i), want)
+			eq("FormatInt32", FormatInt32(-i), strconv.FormatInt(int64(-i), 10))
 		}
 		if n <= math.MaxInt16 {
 			i := int16(n)
-			require.Equal(t, strconv.FormatInt(int64(i), 10), FormatInt16(i), "FormatInt16(%d)", i)
-			require.Equal(t, strconv.FormatInt(int64(-i), 10), FormatInt16(-i), "FormatInt16(%d)", -i)
+			eq("FormatInt16", FormatInt16(i), want)
+			eq("FormatInt16", FormatInt16(-i), strconv.FormatInt(int64(-i), 10))
 		}
 	}
 
@@ -423,12 +432,10 @@ func Test_Format_Sweep(t *testing.T) {
 	require.Equal(t, "-2147483648", FormatInt32(math.MinInt32))
 	require.Equal(t, "-32768", FormatInt16(math.MinInt16))
 
-	// xorshift spread: a few values at every bit length.
-	x := uint64(0x9E3779B97F4A7C15)
+	// A deterministic pseudo-random spread: a few values at every bit length.
+	rng := rand.New(rand.NewSource(1)) //nolint:gosec // deterministic test data
 	for range 20000 {
-		x ^= x << 13
-		x ^= x >> 7
-		x ^= x << 17
+		x := rng.Uint64()
 		check(x)
 		check(x >> (x % 64))
 	}

--- a/hostport.go
+++ b/hostport.go
@@ -17,25 +17,19 @@ func SplitHostPort[S byteSeq](hostport S) (host, port S, ok bool) { //nolint:non
 	if i < 0 {
 		return host, port, false
 	}
-	j, k := 0, 0
+	j, k, hostEnd := 0, 0, i
 	if hostport[0] == '[' {
 		// Expect the first ']' just before the last ':'.
 		end := bytes.IndexByte(b, ']')
 		if end < 0 || end+1 != i {
 			return host, port, false
 		}
-		host = hostport[1:end]
-		j, k = 1, end+1 // there can't be a '[' resp. ']' before these positions
-	} else {
-		host = hostport[:i]
-		if bytes.IndexByte(b[:i], ':') >= 0 {
-			var zero S
-			return zero, port, false
-		}
+		j, k, hostEnd = 1, end+1, end // there can't be a '[' resp. ']' before these positions
+	} else if bytes.IndexByte(b[:i], ':') >= 0 {
+		return host, port, false
 	}
 	if bytes.IndexByte(b[j:], '[') >= 0 || bytes.IndexByte(b[k:], ']') >= 0 {
-		var zero S
-		return zero, port, false
+		return host, port, false
 	}
-	return host, hostport[i+1:], true
+	return hostport[j:hostEnd], hostport[i+1:], true
 }

--- a/hostport_test.go
+++ b/hostport_test.go
@@ -40,28 +40,34 @@ func hostPortSamples() []string {
 	}
 }
 
+// checkSplitHostPort compares both input types with net.SplitHostPort.
+func checkSplitHostPort(tb testing.TB, in string) {
+	tb.Helper()
+	wantHost, wantPort, err := net.SplitHostPort(in)
+	host, port, ok := SplitHostPort(in)
+	require.Equal(tb, err == nil, ok, "input %q: %v", in, err)
+	if !ok {
+		require.Empty(tb, host, "input %q", in)
+		require.Empty(tb, port, "input %q", in)
+	} else {
+		require.Equal(tb, wantHost, host, "input %q", in)
+		require.Equal(tb, wantPort, port, "input %q", in)
+	}
+
+	bh, bp, bok := SplitHostPort([]byte(in))
+	require.Equal(tb, ok, bok, "input %q bytes", in)
+	require.Equal(tb, host, string(bh), "input %q bytes", in)
+	require.Equal(tb, port, string(bp), "input %q bytes", in)
+	if !bok {
+		require.Nil(tb, bh, "input %q bytes", in)
+		require.Nil(tb, bp, "input %q bytes", in)
+	}
+}
+
 func Test_SplitHostPort(t *testing.T) {
 	t.Parallel()
 	for _, in := range hostPortSamples() {
-		wantHost, wantPort, err := net.SplitHostPort(in)
-		host, port, ok := SplitHostPort(in)
-		require.Equal(t, err == nil, ok, "input %q: %v", in, err)
-		if !ok {
-			require.Empty(t, host, "input %q", in)
-			require.Empty(t, port, "input %q", in)
-		} else {
-			require.Equal(t, wantHost, host, "input %q", in)
-			require.Equal(t, wantPort, port, "input %q", in)
-		}
-
-		bh, bp, bok := SplitHostPort([]byte(in))
-		require.Equal(t, ok, bok, "input %q bytes", in)
-		require.Equal(t, host, string(bh), "input %q bytes", in)
-		require.Equal(t, port, string(bp), "input %q bytes", in)
-		if !bok {
-			require.Nil(t, bh)
-			require.Nil(t, bp)
-		}
+		checkSplitHostPort(t, in)
 	}
 
 	// The parts alias the input.
@@ -77,20 +83,7 @@ func FuzzSplitHostPort(f *testing.F) {
 		f.Add(s)
 	}
 	f.Fuzz(func(t *testing.T, s string) {
-		wantHost, wantPort, err := net.SplitHostPort(s)
-		host, port, ok := SplitHostPort(s)
-		require.Equal(t, err == nil, ok)
-		if ok {
-			require.Equal(t, wantHost, host)
-			require.Equal(t, wantPort, port)
-		} else {
-			require.Empty(t, host)
-			require.Empty(t, port)
-		}
-		bh, bp, bok := SplitHostPort([]byte(s))
-		require.Equal(t, ok, bok)
-		require.Equal(t, host, string(bh))
-		require.Equal(t, port, string(bp))
+		checkSplitHostPort(t, s)
 	})
 }
 

--- a/http.go
+++ b/http.go
@@ -28,12 +28,11 @@ const (
 	mimeTableMask       = 1<<mimeTableBits - 1
 	mimeTableMaxEntries = 1 << (mimeTableBits - 1) // half full at most, so probes stay short and always end at a free slot
 	mimeHashMul         = 0x9E3779B97F4A7C15       // Fibonacci hashing multiplier
-	mimeKeyMaxLen       = swar.WordLen
+	mimeKeyMaxLen       = swar.WordLen - 1         // the top lane of a key holds the length
 )
 
 type mimeEntry struct {
 	key      uint64
-	length   uint8
 	mimeType string
 }
 
@@ -46,28 +45,22 @@ func buildMIMETable(exts map[string]string) [1 << mimeTableBits]mimeEntry {
 	var t [1 << mimeTableBits]mimeEntry
 	for ext, mimeType := range exts {
 		if ext == "" || len(ext) > mimeKeyMaxLen {
-			continue // not packable; served by the mime package fallback
+			panic("utils: MIME extension \"" + ext + "\" must be 1.." + FormatInt(mimeKeyMaxLen) + " bytes to fit a packed key")
 		}
 		key := packExtension(ext)
 		h := mimeHash(key)
 		for t[h].mimeType != "" {
 			h = (h + 1) & mimeTableMask
 		}
-		t[h] = mimeEntry{key: key, length: uint8(len(ext)), mimeType: mimeType}
+		t[h] = mimeEntry{key: key, mimeType: mimeType}
 	}
 	return t
 }
 
-// packExtension packs 1..mimeKeyMaxLen bytes into a lower-cased little-endian word.
+// packExtension packs 1..mimeKeyMaxLen bytes lower-cased into a little-endian
+// word with the length in the top lane, so "html\x00" and "html" differ.
 func packExtension(ext string) uint64 {
-	if len(ext) == swar.WordLen {
-		return swar.ToLowerWord(swar.Load8(ext, 0))
-	}
-	var w uint64
-	for i := len(ext) - 1; i >= 0; i-- {
-		w = w<<8 | uint64(ext[i])
-	}
-	return swar.ToLowerWord(w)
+	return foldNeedle(ext) | uint64(len(ext))<<(8*mimeKeyMaxLen)
 }
 
 func mimeHash(key uint64) int {
@@ -87,11 +80,9 @@ func GetMIME(extension string) string {
 		ext = ext[1:]
 	}
 	if len(ext) > 0 && len(ext) <= mimeKeyMaxLen {
-		// The length check keeps NUL bytes in the input apart from the
-		// key's zero padding: "html\x00" must not match "html".
 		key := packExtension(ext)
 		for h := mimeHash(key); mimeTable[h].mimeType != ""; h = (h + 1) & mimeTableMask {
-			if mimeTable[h].key == key && int(mimeTable[h].length) == len(ext) {
+			if mimeTable[h].key == key {
 				return mimeTable[h].mimeType
 			}
 		}

--- a/http_test.go
+++ b/http_test.go
@@ -251,15 +251,11 @@ func Benchmark_StatusMessage(b *testing.B) {
 func Test_GetMIME_TableCoverage(t *testing.T) {
 	t.Parallel()
 	for ext, want := range mimeExtensions {
-		require.NotEmpty(t, ext)
-		require.LessOrEqual(t, len(ext), mimeKeyMaxLen, "extension %q does not fit a packed key", ext)
 		require.Equal(t, want, GetMIME(ext), "extension %q", ext)
 		require.Equal(t, want, GetMIME("."+ext), "extension .%q", ext)
 		require.Equal(t, want, GetMIME(strings.ToUpper(ext)), "extension %q upper-cased", ext)
-		// Trailing NUL bytes pack like the key's zero padding but are a different extension.
-		if len(ext) < mimeKeyMaxLen {
-			require.Equal(t, MIMEOctetStream, GetMIME(ext+"\x00"), "extension %q with a trailing NUL", ext)
-		}
+		// A trailing NUL packs like the key's zero padding but is a different extension.
+		require.Equal(t, MIMEOctetStream, GetMIME(ext+"\x00"), "extension %q with a trailing NUL", ext)
 	}
 	// Distinct extensions must never share a packed key.
 	seen := make(map[uint64]string, len(mimeExtensions))
@@ -269,27 +265,9 @@ func Test_GetMIME_TableCoverage(t *testing.T) {
 		require.False(t, dup, "extensions %q and %q pack to the same key", prev, ext)
 		seen[key] = ext
 	}
-	// Probe sequences must terminate: the table keeps free slots.
-	free := 0
-	for i := range mimeTable {
-		if mimeTable[i].mimeType == "" {
-			free++
-		}
-	}
-	require.Positive(t, free)
-
-	// Entries a packed key cannot hold are skipped and left to the fallback.
-	partial := buildMIMETable(map[string]string{"": "a", "toolongext": "b", "ok": "c"})
-	entries := 0
-	for i := range partial {
-		if partial[i].mimeType != "" {
-			entries++
-			require.Equal(t, packExtension("ok"), partial[i].key)
-		}
-	}
-	require.Equal(t, 1, entries)
-
-	// More entries than the table can hold is a build-time mistake, not a hang.
+	// Entries the table cannot hold are build-time mistakes, not silent fallbacks or hangs.
+	require.Panics(t, func() { buildMIMETable(map[string]string{"": "a"}) })
+	require.Panics(t, func() { buildMIMETable(map[string]string{"toolongext": "b"}) })
 	tooMany := make(map[string]string, mimeTableMaxEntries+1)
 	for i := range mimeTableMaxEntries + 1 {
 		tooMany["e"+FormatInt(int64(i))] = "x"

--- a/parse.go
+++ b/parse.go
@@ -181,10 +181,9 @@ func isEightDigits(w uint64) bool {
 // steps. The caller must have validated that every lane is '0'..'9'.
 func parse8Digits(w uint64) uint64 {
 	const (
-		digitZeros = 0x3030303030303030 // '0' in every lane
-		pairMask   = 0x000000FF000000FF
-		mul1       = 100 + (1000000 << 32)
-		mul2       = 1 + (10000 << 32)
+		pairMask = 0x000000FF000000FF
+		mul1     = 100 + (1000000 << 32)
+		mul2     = 1 + (10000 << 32)
 	)
 	w -= digitZeros
 	w = w*10 + w>>8 // adjacent digit pairs -> 2-digit values in even lanes

--- a/seq.go
+++ b/seq.go
@@ -14,6 +14,7 @@ func SplitTrimSeq[S byteSeq](s S, sep byte) iter.Seq[S] {
 	return func(yield func(S) bool) {
 		rest := s // traversal state stays local, so the sequence can be ranged over again
 		for {
+			// CutByte's body, inline: it is too large to inline into the iterator.
 			i := bytes.IndexByte(unsafeconv.Bytes(rest), sep)
 			elem := rest
 			if i >= 0 {

--- a/seq_test.go
+++ b/seq_test.go
@@ -85,6 +85,26 @@ func Test_SplitTrimSeq(t *testing.T) {
 	}
 }
 
+// countSplitTrimSeq and countSplitSeq range outside the b.Loop body, which
+// disables inlining for calls made directly inside it.
+func countSplitTrimSeq(s string, sep byte) int {
+	n := 0
+	for range SplitTrimSeq(s, sep) {
+		n++
+	}
+	return n
+}
+
+func countSplitSeq(s, sep string) int {
+	n := 0
+	for part := range strings.SplitSeq(s, sep) {
+		if TrimSpace(part) != "" {
+			n++
+		}
+	}
+	return n
+}
+
 func Benchmark_SplitTrimSeq(b *testing.B) {
 	inputs := []struct {
 		name  string
@@ -98,20 +118,13 @@ func Benchmark_SplitTrimSeq(b *testing.B) {
 		b.Run(input.name+"/fiber", func(b *testing.B) {
 			b.ReportAllocs()
 			for b.Loop() {
-				for range SplitTrimSeq(input.value, ',') {
-					count++
-				}
+				count += countSplitTrimSeq(input.value, ',')
 			}
 		})
 		b.Run(input.name+"/default", func(b *testing.B) {
 			b.ReportAllocs()
 			for b.Loop() {
-				for part := range strings.SplitSeq(input.value, ",") {
-					if TrimSpace(part) == "" {
-						continue
-					}
-					count++
-				}
+				count += countSplitSeq(input.value, ",")
 			}
 		})
 	}


### PR DESCRIPTION
# Description

Follow-up to #247: a review pass over the helpers that PR added, for reuse, simplification, and wasted work. No exported signature changes and no output changes; every reworked path stays pinned to the stdlib or its scalar reference by the existing tests and fuzzers, which were re-run after the pass.

Numbers below are base (the #247 merge) vs head on the same machine (`linux/amd64`, Intel Xeon @ 2.80GHz, Go 1.25), interleaved runs, `benchstat -count=10`. The machine ran noticeably slower on this day than for the tables in #247, so only the deltas are comparable with that PR.

Fixes # (no linked issue)

## Performance improvements

### `IndexControl` / `IndexControlExceptTab`

The HTAB exemption was tested in every word (about 40% of the per-word work) although a word without a control byte can never need it. The scan now computes the control mask alone and applies the exemption only to words that hold a control byte. `controlLanes` tests just the control set, the exact byte-exemption test lives in `otherLanes`, and `nonQuotableMask` (the RFC 9110 quoted-string scan) is derived from the same two helpers instead of carrying its own bit trick, so the control-lane test exists once. The composed `nonQuotableMask` was first pushed over the inliner's budget (79 → 84 nodes); splitting the helpers brought it to 72, and `IndexNonQuotable` stays within ±4% on its word paths.

| Benchmark | Before | After | Δ |
|---|---|---|---|
| `IndexControl/clean-16B` | 7.91 ns | 7.14 ns | -10% |
| `IndexControl/clean-64B` | 20.8 ns | 16.3 ns | -21% |
| `IndexControl/ctl-at-end-64B` | 20.0 ns | 17.0 ns | -15% |
| `IndexControlExceptTab/clean-16B` | 7.87 ns | 6.98 ns | -11% |
| `IndexControlExceptTab/clean-64B` | 21.0 ns | 16.3 ns | -22% |
| `IndexControlExceptTab/ctl-at-end-64B` | 19.9 ns | 16.8 ns | -16% |

### `AppendDuration`

`durationFrac` walked all nine (or six, or three) fraction digits with a division each, even for whole-unit values such as `3h4m5s` or `823µs`, the common case for timeouts and latencies. The unit split is now one constant division in the caller (a multiply), a zero fraction writes nothing, and a non-zero one strips its trailing zeros by thousands, then by tens, and writes digit pairs through `putPair`. The `'s'` store is hoisted out of both branches and `durationInt` uses `putPair` too.

| Benchmark | Before | After | Δ |
|---|---|---|---|
| `AppendDuration/micros` (823µs) | 16.8 ns | 12.9 ns | -23% |
| `AppendDuration/millis-frac` (12.345678ms) | 19.5 ns | 20.1 ns | +3% |
| `AppendDuration/hours` (3h4m5s) | 26.7 ns | 15.3 ns | -43% |

### `GetMIME`

The packed key now carries the extension's length in its top lane (`mimeKeyMaxLen` is seven bytes; the longest entry, `jardiff`/`msgpack`, is seven). That makes the key injective on its own, so the `length` field, its probe compare, the NUL-padding comment, and the 8-byte special case in `packExtension` go away, and the entry shrinks from 32 to 24 bytes (table 16 KB → 12 KB). `packExtension` builds on the existing `foldNeedle`. An entry the key or the table cannot hold is now a build-time panic, like the entry-count limit, instead of a silent fallback to `mime.TypeByExtension`, which does not know 13 of the table's entries.

| Benchmark | Before | After | Δ |
|---|---|---|---|
| `GetMIME` (5 lookups per op) | 34.3 ns | 29.7 ns | -13% |

### `SplitHostPort`

One failure-return shape instead of two `var zero S` blocks; the host is sliced on the success line. Valid input is unchanged within noise (`host-port` +4%, `ipv6-port` ~), rejection is faster.

| Benchmark | Before | After | Δ |
|---|---|---|---|
| `SplitHostPort/missing-port` | 11.2 ns | 7.29 ns | -35% |

### Measured and not taken

- Routing 4..7-byte `HasPrefixFold`/`HasSuffixFold` needles through `EqualFold`'s packed compare: a shared helper costs 316 inliner nodes and cannot inline, and behind a call the packed compare lost to the byte loop on 4..5-byte hits (`gzip-hit` +24%) and early misses (`bearer-miss` +92%). Reverted; both keep their byte loop below eight bytes and `EqualFold` keeps its inline path.
- Calling `CutByte` from `SplitTrimSeq`: the generic instantiation is over budget, so it added a call per element (+14% on `gzip, deflate, br`). Kept inline, with a comment saying why.
- Folding `uint32ToBuf` into `uintToBuf`: neutral to 7% slower on `FormatInt32`, so the 32-bit writer stays.

## Other simplifications

- `format.go` and `parse.go` share one `digitZeros` constant.
- Tests: one oracle helper each for `IndexControl` and `SplitHostPort`, used by the table test and the fuzzer; the `EqualFold` length test uses the package's ASCII fold oracle instead of `strings.EqualFold`; `math/rand` replaces two hand-rolled xorshift generators; `slices.Insert` and `bytes.Clone` replace triple appends; the dense sweeps compare directly instead of through `require.Equal`, which took the format sweep from about 8 s to under 1 s under `-race`.
- `Benchmark_SplitTrimSeq` ranges inside a helper function. Calls made directly inside a `b.Loop` body are never inlined, so the old shape reported the iterator closure's allocations (4 allocs, ~110 ns) for a path ordinary callers never take; in a real caller the iterator inlines and allocates nothing. The corrected rows are 0 allocs, 21.5 ns (`Accept-Encoding`) and 59.2 ns (`Accept`) against 24.2 ns and 65.9 ns for the `strings.SplitSeq` + `TrimSpace` spelling, and the README's list-field section now says so instead of claiming the allocations.
- README: prose for the above, and the amd64 block regenerated with a command comment that actually reproduces it (the previous regex did not match the `FormatUint*`/`AppendUint` rows).

## Changes introduced

- [x] Benchmarks: every changed path measured base vs head with interleaved `benchstat -count=10` runs (tables above); the README's amd64 block is regenerated.
- [x] Documentation Update: README sections for control-byte scanning, list field iteration, duration formatting, and decimal formatting.
- [x] Changelog/What's New: faster `IndexControl`/`IndexControlExceptTab`, `AppendDuration`, `GetMIME`, and `SplitHostPort` rejection; no API changes.
- [ ] Migration Guide: not needed, no behavior changes.
- [ ] API Alignment with Express: not applicable to this helper library.
- [x] API Longevity: signatures and outputs unchanged; the MIME table now rejects unpackable entries at init instead of silently skipping them.
- [ ] Examples: none needed, the helpers are unchanged from #247.

## Type of change

- [x] Performance improvement (non-breaking change which improves efficiency)
- [x] Code consistency (non-breaking change which improves code reliability and robustness)

## Checklist

- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [x] Updated the documentation (README; this module has no `/docs/` directory).
- [x] Added or updated unit tests to validate the effectiveness of the changes or new features.
- [x] Ensured that new and existing unit tests pass locally with the changes (`-race -shuffle=on`; golangci-lint v2.12.2 and gofumpt clean; `FuzzIndexControl`, `FuzzGetMIME`, `FuzzSplitHostPort`, `FuzzEqualFold`, `FuzzPrefixSuffixFold`, `FuzzIndexFold` run 20 s each).
- [x] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community (none added).
- [x] Aimed for optimal performance with minimal allocations in the new code.
- [x] Provided benchmarks for the new code to analyze and improve upon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQ4W94jrybuVSabA16uht7

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQ4W94jrybuVSabA16uht7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected numeric parsing for validated ASCII digit sequences.
  * Preserved expected behavior when scanning control characters, including tab exemptions.
  * Maintained consistent host-and-port parsing across string and byte-slice inputs.

* **Performance**
  * Improved efficiency of duration formatting, MIME lookups, and sequence iteration.

* **Documentation**
  * Updated benchmark documentation with clearer methodology and refreshed measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->