### PR TITLE
fix(ips): reject IPv6 hex fields longer than four digits

### DIFF
--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -227,6 +227,23 @@ func FuzzAppendJSONString(f *testing.F) {
 	})
 }
 
+func FuzzIsIP(f *testing.F) {
+	f.Add("127.0.0.1")
+	f.Add("::1")
+	f.Add("00001::2")
+	f.Add("0001:2:3:4:5:6:7:8")
+	f.Add("1:2:3:4:5:6:7:12345")
+	f.Add("fe80::1%eth0")
+	f.Add("::ffff:192.0.2.128")
+	f.Add("::192.168.1.1")
+	f.Add("1::2::3")
+	f.Add(":::")
+	f.Add("")
+	f.Fuzz(func(t *testing.T, s string) {
+		assertIPGrammarParity(t, s)
+	})
+}
+
 func FuzzParseIP(f *testing.F) {
 	f.Add("127.0.0.1")
 	f.Add("01.2.3.4")

--- a/ipparse.go
+++ b/ipparse.go
@@ -13,6 +13,8 @@ import (
 // no leading zeros, nothing before or after — and reports ok=false for
 // everything else, including IPv6 forms. It never allocates, so []byte
 // callers skip both the string conversion and netip's error construction.
+//
+// IsIPv4 is the validate-only counterpart; it accepts the same strings.
 func ParseIPv4[S byteSeq](s S) (netip.Addr, bool) {
 	var b [4]byte
 	n := len(s)
@@ -62,6 +64,10 @@ func ParseIPv4[S byteSeq](s S) (netip.Addr, bool) {
 // including plain IPv4 forms (use ParseIPv4 for those). The parse itself
 // never allocates; only a present zone is materialized as a string because
 // netip.Addr stores zones as strings.
+//
+// IsIPv6 is the validate-only counterpart, but it follows net.ParseIP, which
+// rejects zones. The two therefore disagree on zoned input by design: prefer
+// ParseIPv6 when a zone is acceptable, IsIPv6 when it is not.
 func ParseIPv6[S byteSeq](s S) (netip.Addr, bool) {
 	n := len(s)
 	zone := bytes.IndexByte(unsafeconv.Bytes(s), '%')

--- a/ipparse_test.go
+++ b/ipparse_test.go
@@ -58,6 +58,15 @@ func parseIPSamples() []string {
 		"::1.2.3.4",
 		"1.2.3.4::",
 		"12345::",
+		// Over-long fields whose value still fits in 0xFFFF.
+		"00001::2",
+		"::00000",
+		"00000::",
+		"1:2:3:4:5:6:7:00008",
+		"cec::7dcE:0D568",
+		// Exactly four digits, leading zeros included: valid.
+		"0001:2:3:4:5:6:7:8",
+		"0000::0000",
 		"g::1",
 		"FE80::A:b",
 		"0:0:0:0:0:0:0:0",

--- a/ips.go
+++ b/ips.go
@@ -4,14 +4,13 @@ import (
 	"net"
 )
 
-var hexTable = [256]byte{
-	'0': 0, '1': 1, '2': 2, '3': 3, '4': 4, '5': 5, '6': 6, '7': 7, '8': 8, '9': 9,
-	'a': 10, 'b': 11, 'c': 12, 'd': 13, 'e': 14, 'f': 15,
-	'A': 10, 'B': 11, 'C': 12, 'D': 13, 'E': 14, 'F': 15,
-}
+// hexFieldMaxLen is the number of hex digits an IPv6 field may hold.
+const hexFieldMaxLen = 4
 
-// IsIPv4 works the same way as net.ParseIP,
-// but without check for IPv6 case and without returning net.IP slice, whereby IsIPv4 makes no allocations.
+// IsIPv4 reports whether s is a dotted-decimal IPv4 address. It accepts
+// exactly what net.ParseIP accepts for the IPv4 case, without the net.IP slice,
+// so it makes no allocations. ParseIPv4 is the counterpart that also returns
+// the address; the two agree on every input.
 func IsIPv4(s string) bool {
 	for i := range net.IPv4len {
 		if len(s) == 0 {
@@ -44,8 +43,14 @@ func IsIPv4(s string) bool {
 	return len(s) == 0
 }
 
-// IsIPv6 works the same way as net.ParseIP,
-// but without check for IPv4 case and without returning net.IP slice, whereby IsIPv6 makes no allocations.
+// IsIPv6 reports whether s is an IPv6 address. It accepts exactly what
+// net.ParseIP accepts for the IPv6 case, without the net.IP slice, so it makes
+// no allocations. That excludes a "%zone" suffix, because net.ParseIP rejects
+// zones.
+//
+// ParseIPv6 follows netip.ParseAddr instead and does accept zones, so the two
+// disagree on zoned input by design. Callers relying on IsIPv6 to reject zones
+// must screen '%' themselves before substituting ParseIPv6.
 func IsIPv6(s string) bool {
 	ellipsis := -1 // position of ellipsis in ip
 
@@ -62,21 +67,21 @@ func IsIPv6(s string) bool {
 	// Loop, parsing hex numbers followed by colon.
 	i := 0
 	for i < net.IPv6len {
-		// Hex number.
-		n, ci := 0, 0
-
-		for ci = 0; ci < len(s); ci++ {
-			if (s[ci] < '0' || s[ci] > '9') && (s[ci] < 'a' || s[ci] > 'f') && (s[ci] < 'A' || s[ci] > 'F') {
+		// Hex field. Bounding the digit count is what rejects "00001":
+		// leading zeros hold the value below 0xFFFF however many of them
+		// there are, so a value-only bound lets an over-long field through.
+		// Four digits cannot exceed 0xFFFF, so no value check is needed.
+		ci := 0
+		for ; ci < len(s); ci++ {
+			c := s[ci]
+			if (c < '0' || c > '9') && (c < 'a' || c > 'f') && (c < 'A' || c > 'F') {
 				break
 			}
-			n *= 16
-			n += int(hexTable[s[ci]])
-
-			if n > 0xFFFF {
+			if ci == hexFieldMaxLen {
 				return false
 			}
 		}
-		if ci == 0 || n > 0xFFFF {
+		if ci == 0 {
 			return false
 		}
 

--- a/ips.go
+++ b/ips.go
@@ -9,38 +9,11 @@ const hexFieldMaxLen = 4
 
 // IsIPv4 reports whether s is a dotted-decimal IPv4 address. It accepts
 // exactly what net.ParseIP accepts for the IPv4 case, without the net.IP slice,
-// so it makes no allocations. ParseIPv4 is the counterpart that also returns
-// the address; the two agree on every input.
+// so it makes no allocations. It is the validate-only spelling of ParseIPv4,
+// which accepts the same strings and also returns the address.
 func IsIPv4(s string) bool {
-	for i := range net.IPv4len {
-		if len(s) == 0 {
-			return false
-		}
-
-		if i > 0 {
-			if s[0] != '.' {
-				return false
-			}
-			s = s[1:]
-		}
-
-		n, ci := 0, 0
-
-		for ci = 0; ci < len(s) && '0' <= s[ci] && s[ci] <= '9'; ci++ {
-			n = n*10 + int(s[ci]-'0')
-			if n > 0xFF {
-				return false
-			}
-		}
-
-		if ci == 0 || (ci > 1 && s[0] == '0') {
-			return false
-		}
-
-		s = s[ci:]
-	}
-
-	return len(s) == 0
+	_, ok := ParseIPv4(s)
+	return ok
 }
 
 // IsIPv6 reports whether s is an IPv6 address. It accepts exactly what

--- a/ips_test.go
+++ b/ips_test.go
@@ -6,10 +6,81 @@ package utils
 
 import (
 	"net"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+// assertIPGrammarParity pins the three invariants that tie this module's two IP
+// grammars together: IsIPv4 and IsIPv6 accept exactly what net.ParseIP accepts
+// for their family, and each agrees with the netip-based parser beside it once
+// the zone suffix net.ParseIP rejects is accounted for. Test_IsIP_Parity and
+// FuzzIsIP share it, so the two grammars cannot drift apart unnoticed again.
+func assertIPGrammarParity(t *testing.T, s string) {
+	t.Helper()
+
+	hasColon := strings.ContainsRune(s, ':')
+	netOK := net.ParseIP(s) != nil
+
+	is4 := IsIPv4(s)
+	is6 := IsIPv6(s)
+	if want := netOK && !hasColon; is4 != want {
+		t.Fatalf("IsIPv4(%q) = %v, want %v (net.ParseIP)", s, is4, want)
+	}
+	if want := netOK && hasColon; is6 != want {
+		t.Fatalf("IsIPv6(%q) = %v, want %v (net.ParseIP)", s, is6, want)
+	}
+
+	// net.ParseIP is netip.ParseAddr minus zones, so the parsers agree with the
+	// validators on every input that carries no zone.
+	if _, ok := ParseIPv4(s); ok != is4 {
+		t.Fatalf("ParseIPv4(%q) ok = %v but IsIPv4 = %v", s, ok, is4)
+	}
+	addr, ok6 := ParseIPv6(s)
+	if want := ok6 && addr.Zone() == ""; want != is6 {
+		t.Fatalf("ParseIPv6(%q) ok = %v zone = %q but IsIPv6 = %v", s, ok6, addr.Zone(), is6)
+	}
+}
+
+// Test_IsIP_Parity runs the shared IP corpus through both grammars.
+func Test_IsIP_Parity(t *testing.T) {
+	t.Parallel()
+
+	for _, in := range parseIPSamples() {
+		assertIPGrammarParity(t, in)
+	}
+}
+
+// Test_IsIPv6_HexFieldDigitCap covers fields longer than four hex digits whose
+// value still fits in 0xFFFF. A value-only bound accepted these; net.ParseIP,
+// the reference IsIPv6 follows, rejects them.
+func Test_IsIPv6_HexFieldDigitCap(t *testing.T) {
+	t.Parallel()
+
+	for _, in := range []string{
+		"00001::2",
+		"cec::7dcE:0D568",
+		"::00000",
+		"00000::",
+		"1:2:3:4:5:6:7:00008",
+		"00000000000000001::",
+	} {
+		require.False(t, IsIPv6(in), "over-long hex field: %q", in)
+		require.Nil(t, net.ParseIP(in), "net.ParseIP disagrees: %q", in)
+	}
+
+	// Exactly four digits stays valid, leading zeros included.
+	for _, in := range []string{
+		"0001:2:3:4:5:6:7:8",
+		"0000::0000",
+		"::0001",
+		"ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+	} {
+		require.True(t, IsIPv6(in), "four-digit field rejected: %q", in)
+		require.NotNil(t, net.ParseIP(in), "net.ParseIP disagrees: %q", in)
+	}
+}
 
 func Test_IsIPv4(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
# Description

`IsIPv6` accepted addresses that are not valid IPv6. It bounded the accumulated **value** of a hex field at `0xFFFF` but never bounded the **digit count**, so leading zeros walked straight past the check:

```go
utils.IsIPv6("00001::2")         // true  — should be false
utils.IsIPv6("cec::7dcE:0D568")  // true  — should be false
net.ParseIP("00001::2")          // nil   — the reference IsIPv6 documents itself against
```

The existing guard against over-long fields only covered `"12345"`, whose value overflows `0xFFFF`; once leading zeros keep the value small, nothing rejected the field. `net.ParseIP` — which `IsIPv6` documents itself as matching — delegates to `netip.ParseAddr` in current Go and caps a field at four hex digits.

This bounds the digit count instead. Four hex digits cannot exceed `0xFFFF`, so the value checks become dead and go, and with them the last reader of the package's second hex table.

While here: `IsIPv4` and `ParseIPv4` were two implementations of one grammar accepting exactly the same strings, so `IsIPv4` now derives from `ParseIPv4`. `IsIPv6` deliberately keeps its own scanner — see the compatibility note below.

No linked issue; found by differential testing against `net.ParseIP`.

## Changes introduced

- **Benchmarks:** measured with benchstat, `n=15`, samples **interleaved** between the two revisions so drift affects both equally. The `default` sub-benchmarks call `net.ParseIP` and cannot be affected by this change, so they serve as controls — both hold at `~`, and variance is ±1–2%.

  ```
                           │   master    │               branch                │
  _IsIPv4/fiber-4            22.96n ± 1%   21.63n ± 2%   -5.79% (p=0.000 n=15)
  _IsIPv4/default-4          40.26n ± 2%   40.11n ± 1%        ~ (p=0.309 n=15)  ← control
  _IsIPv6/fiber-4            82.21n ± 1%   62.40n ± 1%  -24.10% (p=0.000 n=15)
  _IsIPv6/default-4          89.37n ± 1%   89.69n ± 2%        ~ (p=0.660 n=15)  ← control
  ```

  The `IsIPv6` gain is from the fix, not the refactor: the old loop did a multiply, a 256-byte table load and a compare per hex digit — roughly 32 of each for a full address. Allocations are 0 on every row, both revisions, unchanged.

  `IsIPv6`'s embedded-IPv4 branch is the one path the `IsIPv4` refactor changes, and no benchmark covers it. Measured with a temporary benchmark added to both revisions: `::ffff:192.0.2.128` −18.78%, `::192.168.1.1` −11.09%, `1:2:3:4:5:6:1.2.3.4` −10.46%, `::ffff:256.0.0.1` (reject path) −8.93%, all `p=0.000`, 0 allocs. It is not in the diff — worth considering as a permanent addition to `Benchmark_IsIPv6`, which currently has no embedded-IPv4 input at all.

  **README block regenerated** in 94fe06f (`README.md:400-403`), touched paths only: medians of `-count=10` with the machine idle, then `make benchfmt` for the column layout. Both `default` rows were regenerated alongside the `fiber` ones so the block stays an internally consistent fiber-vs-stdlib comparison on one machine — quoting a 4-vCPU `fiber` number against a 12-core `default` number would make the comparison meaningless. Absolute values rise (`IsIPv4/fiber` 14.58 → 21.72, `IsIPv6/fiber` 42.67 → 62.01 ns/op) purely because this run is on 4 vCPU where the previous block was 12-core; the catalog already carries both, 393 rows at `-12` and 271 at `-4`. The improvement itself is the same-machine benchstat above.

- **Documentation update:** doc comments rewritten on all four functions. `IsIPv6` now states that it follows `net.ParseIP` and therefore rejects a `%zone` suffix, and names `ParseIPv6` as the zone-accepting alternative; `ParseIPv4`/`ParseIPv6` name their validate-only counterparts in return. This split was previously documented nowhere despite downstream code depending on it. No `/docs/` directory in this repository.

- **Changelog / What's New:** nothing added manually; release-drafter builds notes from the PR title and labels.

- **Migration guide:** not needed, but there is a compatibility note. `IsIPv6` now **rejects** input it previously accepted (over-long hex fields). `gofiber/fiber` pins `utils v2.5.1` and uses `IsIPv6` at `req.go:871` and `req.go:957` to filter `X-Forwarded-For` tokens, so on a version bump values like `00001::2` stop appearing in `c.IPs()` and stop being considered for trusted-proxy matching. That is the intended effect — those strings are not valid IPv6 — but it is a narrowing of accepted input rather than a pure internal fix.

- **API longevity:** no signature changes, no new exported API. The contract each function follows is now stated in its doc comment and pinned by a shared test oracle, so the two grammars cannot drift apart again without CI noticing.

- **API alignment with Express / Examples:** not applicable to this repository.

## Type of change

The template has no "bug fix" option; this is primarily a correctness fix, with the rest falling out of it.

- [x] Enhancement (improvement to existing features and functionality) — `IsIPv6` now matches the contract it documents
- [x] Performance improvement (non-breaking change which improves efficiency) — `IsIPv6` −24.10%, `IsIPv4` −5.79%
- [x] Documentation update (changes to documentation) — the zone split is now stated on all four functions
- [x] Code consistency (non-breaking change which improves code reliability and robustness) — one IPv4 grammar instead of two, equivalence enforced by tests

## Checklist

- [x] Conducted a self-review of the code and provided comments for complex or critical parts.
- [x] Added or updated unit tests to validate the effectiveness of the changes or new features.

  `assertIPGrammarParity` is a single shared oracle pinning both validators to `net.ParseIP` and to the `netip`-based parsers beside them, modulo the zone suffix `net.ParseIP` rejects. It is driven from a table test over the existing `parseIPSamples` corpus (extended with the leading-zero shapes, so the `ParseIPv4`/`ParseIPv6` tests pick them up too) and from a new `FuzzIsIP`. `IsIPv4`/`IsIPv6` previously had no property test, which is why this survived.

- [x] Ensured that new and existing unit tests pass locally with the changes.

  Full suite green under `-race -shuffle=on`. `FuzzIsIP`: 1,042,493 executions, no failures. Ad-hoc differential harness: 100,016 inputs (including 40,000 generated dotted-decimal and leading-zero shapes), zero divergence across six invariants. `go vet` clean. golangci-lint **v2.12.2** reports 0 issues — note the version pinned in `Makefile:39` (v2.6.1) cannot run against a `go 1.26` module at all, which is a pre-existing problem unrelated to this PR.

- [x] Verified that any new dependencies are essential and have been agreed upon by the maintainers/community.

  None added.

- [x] Aimed for optimal performance with minimal allocations in the new code.

  Zero allocations, unchanged; both functions got faster.

- [x] Provided benchmarks for the new code to analyze and improve upon.

  Interleaved benchstat above, and the README catalog block is regenerated.

- [ ] Followed the inspiration of the Express.js framework for new functionalities — not applicable; no new functionality and this is not the framework repository.
- [ ] Updated the documentation in the `/docs/` directory — not applicable; this repository has no `/docs/`. Doc comments and the README function catalog are the documentation, and both are updated.

## Commit formatting

Four commits, following this repository's existing conventional-commit style (`fix(ips):`, `docs(ipparse):`, `refactor(ips):`, `docs(readme):`) rather than the emoji convention used in `gofiber/fiber`, to match the surrounding history here. They are separable: the correctness fix does not depend on the refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7Z8sz85kpAwQKxoeFBv7i